### PR TITLE
feat: add GitHub Pages PR preview deployments

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -133,15 +133,7 @@ jobs:
               comment.body.includes('Preview deployment')
             );
 
-            const body = `## Preview deployment
-
-Your preview is ready!
-
-| Preview URL | Updated |
-|-------------|---------|
-| ${previewUrl} | ${new Date().toISOString()} |
-
-This preview will remain available even after the PR is merged or closed.`;
+            const body = `## Preview deployment\n\nYour preview is ready!\n\n| Preview URL | Updated |\n|-------------|---------|\n| ${previewUrl} | ${new Date().toISOString()} |\n\nThis preview will remain available even after the PR is merged or closed.`;
 
             if (botComment) {
               // Update existing comment


### PR DESCRIPTION
- Add pull_request trigger for opened, synchronize, reopened events
- Deploy PR previews to /pr-<number>/ subdirectory on gh-pages branch
- Auto-comment on PR with preview URL (updates existing comment)
- Switch to peaceiris/actions-gh-pages@v3 for both main and PR deployments
- Use keep_files: true to preserve PR previews across main deployments
- Add contents: write and pull-requests: write permissions

https://claude.ai/code/session_01WRYWCABdC5HuXUUXPtKwUd