### PR TITLE
Adjust scheduled workflow to run at 6am PST instead of UTC

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1,9 +1,9 @@
 name: Update Data & Deploy
 
 on:
-  # Run daily at 6am UTC
+  # Run daily at 6am PST (2pm UTC). PST = UTC-8.
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 14 * * *'
   # Manual trigger
   workflow_dispatch:
   # Run on push to main or claude branches


### PR DESCRIPTION
## Summary
Updated the scheduled workflow timing to run at 6am PST (Pacific Standard Time) instead of 6am UTC, which is 2pm UTC.

## Changes
- Modified the cron schedule in `.github/workflows/update-data.yml` from `0 6 * * *` to `0 14 * * *`
- Updated the comment to clarify the timezone: "Run daily at 6am PST (2pm UTC). PST = UTC-8."

## Details
The cron schedule now triggers the "Update Data & Deploy" workflow at 14:00 UTC (2pm), which corresponds to 6:00 AM PST. This adjustment ensures the workflow runs at the intended local time for the team/organization operating in the PST timezone.

https://claude.ai/code/session_018xNVB1nu3NYT13Fz5xxmEX