### PR TITLE
Add shared HTTP client with retry and exponential backoff

### DIFF
--- a/src/butterfly_planner/flows/fetch.py
+++ b/src/butterfly_planner/flows/fetch.py
@@ -18,11 +18,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-import requests
 from prefect import flow, task
 
 from butterfly_planner import inaturalist, sunshine
 from butterfly_planner.services import weather
+from butterfly_planner.services.http import session
 
 # Data directories
 DATA_DIR = Path("data")
@@ -55,7 +55,7 @@ def fetch_weather(lat: float = 45.5, lon: float = -122.6) -> dict[str, Any]:
         "forecast_days": 16,
     }
 
-    resp = requests.get(url, params=params, timeout=30)
+    resp = session.get(url, params=params)
     resp.raise_for_status()
     result: dict[str, Any] = resp.json()
     return result

--- a/src/butterfly_planner/services/http.py
+++ b/src/butterfly_planner/services/http.py
@@ -1,0 +1,66 @@
+"""
+Shared HTTP client with automatic retry and backoff.
+
+Provides a pre-configured ``requests.Session`` that retries on transient
+network errors (timeouts, connection resets, 502/503/504) with exponential
+backoff.  All service modules should use this instead of bare ``requests.get``.
+
+Usage::
+
+    from butterfly_planner.services.http import session
+
+    resp = session.get("https://api.example.com/v1/data", timeout=30)
+    resp.raise_for_status()
+"""
+
+from __future__ import annotations
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+#: Default retry strategy — handles the transient errors we see in practice.
+DEFAULT_RETRY = Retry(
+    total=4,
+    backoff_factor=2,  # 0s, 2s, 4s, 8s between retries
+    status_forcelist=[429, 502, 503, 504],
+    allowed_methods=["GET", "HEAD", "OPTIONS"],
+    raise_on_status=False,  # let resp.raise_for_status() handle it
+)
+
+DEFAULT_TIMEOUT = 30  # seconds
+
+
+def create_session(
+    retry: Retry | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> requests.Session:
+    """
+    Build a ``requests.Session`` with retry adapter mounted.
+
+    Args:
+        retry: Custom retry strategy (defaults to ``DEFAULT_RETRY``).
+        timeout: Default timeout applied to every request.
+    """
+    s = requests.Session()
+    adapter = HTTPAdapter(max_retries=retry or DEFAULT_RETRY)
+    s.mount("https://", adapter)
+    s.mount("http://", adapter)
+    s.headers["User-Agent"] = "butterfly-planner/0.1 (https://github.com/mihow/butterfly-planner)"
+
+    # Monkey-patch send to inject a default timeout so callers don't need to
+    # remember to pass ``timeout=`` every time.
+    _original_send = s.send
+
+    def _send_with_timeout(
+        prepared: requests.PreparedRequest, **kwargs: object
+    ) -> requests.Response:
+        kwargs.setdefault("timeout", timeout)
+        return _original_send(prepared, **kwargs)  # type: ignore[arg-type]
+
+    s.send = _send_with_timeout  # type: ignore[method-assign]
+    return s
+
+
+#: Module-level session — import and use directly.
+session: requests.Session = create_session()

--- a/src/butterfly_planner/services/inat.py
+++ b/src/butterfly_planner/services/inat.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import time
 from typing import Any
 
-import requests
+from butterfly_planner.services.http import session
 
 # ---------------------------------------------------------------------------
 # Taxon IDs
@@ -32,7 +32,6 @@ WASHINGTON = 46
 # API configuration
 # ---------------------------------------------------------------------------
 API_BASE = "https://api.inaturalist.org/v1"
-USER_AGENT = "butterfly-planner/0.1 (https://github.com/mihow/butterfly-planner)"
 MAX_PER_PAGE = 200  # API maximum for /observations
 MAX_RESULTS = 10_000  # API hard ceiling per query
 
@@ -57,8 +56,7 @@ def _get(endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
     """Make a rate-limited GET request to the iNaturalist API v1."""
     _rate_limit()
     url = f"{API_BASE}/{endpoint}"
-    headers = {"User-Agent": USER_AGENT}
-    resp = requests.get(url, params=params or {}, headers=headers, timeout=30)
+    resp = session.get(url, params=params or {})
     resp.raise_for_status()
     data: dict[str, Any] = resp.json()
     return data

--- a/src/butterfly_planner/services/weather.py
+++ b/src/butterfly_planner/services/weather.py
@@ -14,12 +14,10 @@ from __future__ import annotations
 
 from typing import Any
 
-import requests
+from butterfly_planner.services.http import session
 
 OPEN_METEO_API = "https://api.open-meteo.com/v1/forecast"
 OPEN_METEO_HISTORICAL = "https://archive-api.open-meteo.com/v1/archive"
-
-USER_AGENT = "butterfly-planner/0.1 (https://github.com/mihow/butterfly-planner)"
 
 # Daily variables we request from the archive API
 _DAILY_VARS = [
@@ -56,8 +54,7 @@ def fetch_historical_daily(
         "daily": _DAILY_VARS,
         "timezone": "America/Los_Angeles",
     }
-    headers = {"User-Agent": USER_AGENT}
-    resp = requests.get(OPEN_METEO_HISTORICAL, params=params, headers=headers, timeout=30)
+    resp = session.get(OPEN_METEO_HISTORICAL, params=params)
     resp.raise_for_status()
     result: dict[str, Any] = resp.json()
     return result

--- a/src/butterfly_planner/sunshine.py
+++ b/src/butterfly_planner/sunshine.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from typing import Any
 
-import requests
+from butterfly_planner.services.http import session
 
 # Open-Meteo API endpoints
 FORECAST_API = "https://api.open-meteo.com/v1/forecast"
@@ -164,7 +164,7 @@ def fetch_today_15min_sunshine(
         "forecast_days": forecast_days,
     }
 
-    resp = requests.get(FORECAST_API, params=params, timeout=30)
+    resp = session.get(FORECAST_API, params=params)
     resp.raise_for_status()
     data: dict[str, Any] = resp.json()
 
@@ -204,7 +204,7 @@ def fetch_16day_sunshine(
         "forecast_days": 16,
     }
 
-    resp = requests.get(FORECAST_API, params=params, timeout=30)
+    resp = session.get(FORECAST_API, params=params)
     resp.raise_for_status()
     data: dict[str, Any] = resp.json()
 
@@ -261,7 +261,7 @@ def fetch_ensemble_sunshine(
         "forecast_days": forecast_days,
     }
 
-    resp = requests.get(ENSEMBLE_API, params=params, timeout=60)
+    resp = session.get(ENSEMBLE_API, params=params, timeout=60)
     resp.raise_for_status()
     data: dict[str, Any] = resp.json()
 

--- a/tests/test_flows_fetch.py
+++ b/tests/test_flows_fetch.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 class TestFetchWeather:
     """Test fetching weather data from API."""
 
-    @patch("butterfly_planner.flows.fetch.requests.get")
+    @patch("butterfly_planner.flows.fetch.session.get")
     def test_fetch_weather(self, mock_get: Mock) -> None:
         """Test fetching weather data from Open-Meteo."""
         mock_response = Mock()
@@ -308,7 +308,7 @@ class TestFetchAllFlow:
     @patch("butterfly_planner.flows.fetch.inaturalist.fetch_species_counts")
     @patch("butterfly_planner.flows.fetch.sunshine.fetch_today_15min_sunshine")
     @patch("butterfly_planner.flows.fetch.sunshine.fetch_16day_sunshine")
-    @patch("butterfly_planner.flows.fetch.requests.get")
+    @patch("butterfly_planner.flows.fetch.session.get")
     def test_fetch_all(
         self,
         mock_get: Mock,

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,98 @@
+"""Tests for the shared HTTP client with retry logic."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import requests
+from urllib3.util.retry import Retry
+
+from butterfly_planner.services.http import DEFAULT_RETRY, DEFAULT_TIMEOUT, create_session, session
+
+
+class TestDefaultRetry:
+    """Verify retry strategy configuration."""
+
+    def test_total_retries(self) -> None:
+        assert DEFAULT_RETRY.total == 4
+
+    def test_backoff_factor(self) -> None:
+        assert DEFAULT_RETRY.backoff_factor == 2
+
+    def test_retries_on_server_errors(self) -> None:
+        assert 502 in DEFAULT_RETRY.status_forcelist
+        assert 503 in DEFAULT_RETRY.status_forcelist
+        assert 504 in DEFAULT_RETRY.status_forcelist
+
+    def test_retries_on_rate_limit(self) -> None:
+        assert 429 in DEFAULT_RETRY.status_forcelist
+
+    def test_only_safe_methods(self) -> None:
+        allowed = DEFAULT_RETRY.allowed_methods
+        assert "GET" in allowed
+        assert "POST" not in allowed
+
+
+class TestCreateSession:
+    """Verify session factory."""
+
+    def test_returns_session(self) -> None:
+        s = create_session()
+        assert isinstance(s, requests.Session)
+
+    def test_mounts_https_adapter(self) -> None:
+        s = create_session()
+        adapter = s.get_adapter("https://example.com")
+        assert isinstance(adapter, requests.adapters.HTTPAdapter)
+
+    def test_mounts_http_adapter(self) -> None:
+        s = create_session()
+        adapter = s.get_adapter("http://example.com")
+        assert isinstance(adapter, requests.adapters.HTTPAdapter)
+
+    def test_adapter_has_retry(self) -> None:
+        s = create_session()
+        adapter = s.get_adapter("https://example.com")
+        assert adapter.max_retries.total == 4
+
+    def test_custom_retry(self) -> None:
+        custom = Retry(total=10, backoff_factor=1)
+        s = create_session(retry=custom)
+        adapter = s.get_adapter("https://example.com")
+        assert adapter.max_retries.total == 10
+
+    def test_user_agent_header(self) -> None:
+        s = create_session()
+        assert "butterfly-planner" in s.headers["User-Agent"]
+
+    def test_default_timeout_injected(self) -> None:
+        s = create_session(timeout=42)
+        prep = requests.Request("GET", "https://example.com").prepare()
+        # Patch the bound method captured by the closure
+        with patch.object(
+            requests.adapters.HTTPAdapter, "send", return_value=requests.Response()
+        ) as mock_send:
+            s.send(prep)
+            _, kwargs = mock_send.call_args
+            assert kwargs.get("timeout") == 42
+
+    def test_explicit_timeout_not_overridden(self) -> None:
+        s = create_session(timeout=42)
+        prep = requests.Request("GET", "https://example.com").prepare()
+        with patch.object(
+            requests.adapters.HTTPAdapter, "send", return_value=requests.Response()
+        ) as mock_send:
+            s.send(prep, timeout=99)
+            _, kwargs = mock_send.call_args
+            assert kwargs.get("timeout") == 99
+
+
+class TestModuleSession:
+    """Verify the module-level singleton."""
+
+    def test_session_is_configured(self) -> None:
+        adapter = session.get_adapter("https://example.com")
+        assert adapter.max_retries.total == 4
+
+    def test_default_timeout(self) -> None:
+        assert DEFAULT_TIMEOUT == 30

--- a/tests/test_inaturalist.py
+++ b/tests/test_inaturalist.py
@@ -574,7 +574,7 @@ class TestInatClient:
     def test_max_per_page(self) -> None:
         assert inat.MAX_PER_PAGE == 200
 
-    @patch("butterfly_planner.services.inat.requests.get")
+    @patch("butterfly_planner.services.inat.session.get")
     def test_get_observations_calls_api(self, mock_get: object) -> None:
         mock_resp = mock_get.return_value  # type: ignore[union-attr]
         mock_resp.json.return_value = {"results": [], "total_results": 0}
@@ -587,7 +587,7 @@ class TestInatClient:
         assert result == {"results": [], "total_results": 0}
         mock_get.assert_called_once()  # type: ignore[union-attr]
 
-    @patch("butterfly_planner.services.inat.requests.get")
+    @patch("butterfly_planner.services.inat.session.get")
     def test_get_species_counts_calls_api(self, mock_get: object) -> None:
         mock_resp = mock_get.return_value  # type: ignore[union-attr]
         mock_resp.json.return_value = {"results": [], "total_results": 0}
@@ -601,7 +601,7 @@ class TestInatClient:
         call_url = mock_get.call_args[0][0]  # type: ignore[union-attr]
         assert "species_counts" in call_url
 
-    @patch("butterfly_planner.services.inat.requests.get")
+    @patch("butterfly_planner.services.inat.session.get")
     def test_pagination_stops_on_empty(self, mock_get: object) -> None:
         mock_resp = mock_get.return_value  # type: ignore[union-attr]
         mock_resp.json.return_value = {"results": [], "total_results": 0}
@@ -614,7 +614,7 @@ class TestInatClient:
         # Should stop after first empty page
         assert mock_get.call_count == 1  # type: ignore[union-attr]
 
-    @patch("butterfly_planner.services.inat.requests.get")
+    @patch("butterfly_planner.services.inat.session.get")
     def test_pagination_uses_id_above(self, mock_get: object) -> None:
         # First page returns results, second page empty
         page1 = {"results": [{"id": 100}, {"id": 200}], "total_results": 2}

--- a/tests/test_sunshine.py
+++ b/tests/test_sunshine.py
@@ -171,7 +171,7 @@ class TestEnsembleSunshine:
 class TestFetchFunctions:
     """Test API fetching functions."""
 
-    @patch("butterfly_planner.sunshine.requests.get")
+    @patch("butterfly_planner.sunshine.session.get")
     def test_fetch_today_15min_sunshine(self, mock_get: Mock) -> None:
         """Test fetching 15-minute sunshine data."""
         mock_response = Mock()
@@ -200,7 +200,7 @@ class TestFetchFunctions:
         assert call_args.kwargs["params"]["longitude"] == -122.6
         assert call_args.kwargs["params"]["forecast_days"] == 1
 
-    @patch("butterfly_planner.sunshine.requests.get")
+    @patch("butterfly_planner.sunshine.session.get")
     def test_fetch_16day_sunshine(self, mock_get: Mock) -> None:
         """Test fetching 16-day sunshine data."""
         mock_response = Mock()
@@ -225,7 +225,7 @@ class TestFetchFunctions:
         call_args = mock_get.call_args
         assert call_args.kwargs["params"]["forecast_days"] == 16
 
-    @patch("butterfly_planner.sunshine.requests.get")
+    @patch("butterfly_planner.sunshine.session.get")
     def test_fetch_ensemble_sunshine(self, mock_get: Mock) -> None:
         """Test fetching ensemble sunshine data."""
         mock_response = Mock()


### PR DESCRIPTION
All HTTP requests used bare requests.get() with no retry logic.
ReadTimeout errors from archive-api.open-meteo.com crashed the
fetch step without retrying. Prefect task-level retries existed but
used fixed 5s delays and only 2 attempts.

New services/http.py provides a pre-configured requests.Session with
urllib3 Retry (4 retries, exponential backoff factor 2, retries on
429/502/503/504). All services now use this shared session instead of
bare requests.get(), giving consistent retry behavior across weather,
iNaturalist, and sunshine API calls with no new dependencies.

https://claude.ai/code/session_017VLUXRsVndfyXUBdyuXEQf