### PR TITLE
Mobile responsive tables and vibrant color palette

### DIFF
--- a/src/butterfly_planner/templates/base.html.j2
+++ b/src/butterfly_planner/templates/base.html.j2
@@ -100,12 +100,12 @@
         .tl-seg { flex: 1; min-width: 0; transition: opacity 0.15s; }
         .tl-seg:hover { opacity: 0.65; }
 
-        /* --- Sunshine color scale (vibrant warm palette) --- */
+        /* --- Sunshine color scale (muddy pale → bright lemon) --- */
         .sunshine-none { background: #e8e8e8; }
-        .sunshine-low  { background: #fff3b0; }
-        .sunshine-med  { background: #ffd43b; }
-        .sunshine-high { background: #ff922b; }
-        .sunshine-full { background: #ff6b2b; }
+        .sunshine-low  { background: #f5eec2; }
+        .sunshine-med  { background: #f0e068; }
+        .sunshine-high { background: #f5e642; }
+        .sunshine-full { background: #fff44f; }
 
         /* --- Inline hourly bar (16-day table) --- */
         .hour-bar { display: inline-flex; gap: 1px; vertical-align: middle; }

--- a/src/butterfly_planner/templates/base.html.j2
+++ b/src/butterfly_planner/templates/base.html.j2
@@ -262,25 +262,13 @@
 
         /* --- Mobile responsive --- */
         @media (max-width: 640px) {
-            body { padding: 1.5rem 0.75rem; }
+            body { padding: 1.5rem 0.75rem; overflow-x: hidden; }
             header h1 { font-size: 1.4rem; }
 
-            /* Fat rows: stack table cells vertically on mobile */
-            table.fat-rows thead { display: none; }
-            table.fat-rows tbody tr {
-                display: block;
-                padding: 0.75rem;
-                border-bottom: 1px solid #ddd;
-                margin-bottom: 0.25rem;
-            }
-            table.fat-rows tbody td {
-                display: block;
-                border: none;
-                padding: 0.15rem 0;
-            }
-
             /* Sightings table: photo + name side-by-side, count below */
+            table.sightings-table { display: block; width: 100%; }
             table.sightings-table thead { display: none; }
+            table.sightings-table tbody { display: block; }
             table.sightings-table tbody tr {
                 display: grid;
                 grid-template-columns: 48px 1fr;
@@ -290,12 +278,17 @@
                 border-bottom: 1px solid #eee;
                 align-items: center;
             }
+            table.sightings-table tbody td {
+                display: block;
+                border: none;
+                padding: 0.1rem 0;
+                min-width: 0;
+                overflow: hidden;
+            }
             table.sightings-table tbody td:first-child {
                 grid-row: 1 / 3;
-                width: auto;
             }
             table.sightings-table tbody td:nth-child(2) {
-                min-width: 0;
                 grid-column: 2;
             }
             table.sightings-table tbody td.obs-count {
@@ -303,10 +296,13 @@
                 font-size: 0.8rem;
                 color: #666;
             }
+            .obs-bar { max-width: 100px; }
             .species-scientific { padding-left: 0; font-size: 0.82rem; }
 
             /* 16-day forecast: fat rows with labels */
+            table.forecast-table { display: block; width: 100%; }
             table.forecast-table thead { display: none; }
+            table.forecast-table tbody { display: block; }
             table.forecast-table tbody tr {
                 display: grid;
                 grid-template-columns: 1fr 1fr;
@@ -315,8 +311,11 @@
                 border-bottom: 1px solid #eee;
             }
             table.forecast-table tbody td {
+                display: block;
                 border: none;
                 padding: 0.1rem 0;
+                min-width: 0;
+                overflow: hidden;
             }
             table.forecast-table tbody td::before {
                 display: inline;

--- a/src/butterfly_planner/templates/base.html.j2
+++ b/src/butterfly_planner/templates/base.html.j2
@@ -100,12 +100,12 @@
         .tl-seg { flex: 1; min-width: 0; transition: opacity 0.15s; }
         .tl-seg:hover { opacity: 0.65; }
 
-        /* --- Sunshine color scale (muted, scientific palette) --- */
+        /* --- Sunshine color scale (vibrant warm palette) --- */
         .sunshine-none { background: #e8e8e8; }
-        .sunshine-low  { background: #f5eec2; }
-        .sunshine-med  { background: #e8d44d; }
-        .sunshine-high { background: #d4a017; }
-        .sunshine-full { background: #b8860b; }
+        .sunshine-low  { background: #fff3b0; }
+        .sunshine-med  { background: #ffd43b; }
+        .sunshine-high { background: #ff922b; }
+        .sunshine-full { background: #ff6b2b; }
 
         /* --- Inline hourly bar (16-day table) --- */
         .hour-bar { display: inline-flex; gap: 1px; vertical-align: middle; }
@@ -212,7 +212,7 @@
         .gdd-track-bar {
             flex: 1;
             height: 6px;
-            background: linear-gradient(to right, #4363d8, #e8d44d, #e6194b);
+            background: linear-gradient(to right, #4363d8, #ffd43b, #ff6b2b);
             border-radius: 3px;
             position: relative;
         }
@@ -258,6 +258,99 @@
             text-align: center;
             font-size: 0.85rem;
             color: #888;
+        }
+
+        /* --- Mobile responsive --- */
+        @media (max-width: 640px) {
+            body { padding: 1.5rem 0.75rem; }
+            header h1 { font-size: 1.4rem; }
+
+            /* Fat rows: stack table cells vertically on mobile */
+            table.fat-rows thead { display: none; }
+            table.fat-rows tbody tr {
+                display: block;
+                padding: 0.75rem;
+                border-bottom: 1px solid #ddd;
+                margin-bottom: 0.25rem;
+            }
+            table.fat-rows tbody td {
+                display: block;
+                border: none;
+                padding: 0.15rem 0;
+            }
+
+            /* Sightings table: photo + name side-by-side, count below */
+            table.sightings-table thead { display: none; }
+            table.sightings-table tbody tr {
+                display: grid;
+                grid-template-columns: 48px 1fr;
+                grid-template-rows: auto auto;
+                gap: 0 0.75rem;
+                padding: 0.65rem 0.5rem;
+                border-bottom: 1px solid #eee;
+                align-items: center;
+            }
+            table.sightings-table tbody td:first-child {
+                grid-row: 1 / 3;
+                width: auto;
+            }
+            table.sightings-table tbody td:nth-child(2) {
+                min-width: 0;
+                grid-column: 2;
+            }
+            table.sightings-table tbody td.obs-count {
+                grid-column: 2;
+                font-size: 0.8rem;
+                color: #666;
+            }
+            .species-scientific { padding-left: 0; font-size: 0.82rem; }
+
+            /* 16-day forecast: fat rows with labels */
+            table.forecast-table thead { display: none; }
+            table.forecast-table tbody tr {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                gap: 0.15rem 0.75rem;
+                padding: 0.65rem 0.5rem;
+                border-bottom: 1px solid #eee;
+            }
+            table.forecast-table tbody td {
+                border: none;
+                padding: 0.1rem 0;
+            }
+            table.forecast-table tbody td::before {
+                display: inline;
+                font-size: 0.7rem;
+                text-transform: uppercase;
+                color: #888;
+                margin-right: 0.3rem;
+            }
+            table.forecast-table tbody td:nth-child(1) {
+                grid-column: 1 / -1;
+                font-weight: 600;
+            }
+            table.forecast-table tbody td:nth-child(2)::before { content: "Sun: "; }
+            table.forecast-table tbody td:nth-child(3)::before { content: ""; }
+            table.forecast-table tbody td:nth-child(4)::before { content: ""; }
+            table.forecast-table tbody td:nth-child(5)::before { content: "Rain: "; }
+            table.forecast-table tbody td:nth-child(6) {
+                grid-column: 1 / -1;
+                text-align: right;
+                font-size: 0.85rem;
+            }
+
+            /* Hourly bars: hide on mobile to save space */
+            .hour-bar { display: none; }
+
+            /* Map height reduction */
+            #sightings-map { height: 300px; }
+
+            /* GDD card */
+            .gdd-stats { gap: 1rem; }
+            .gdd-card { padding: 1rem; }
+
+            /* GDD timeline: allow scroll */
+            .gdd-timeline-container { overflow-x: auto; -webkit-overflow-scrolling: touch; }
         }
 
         /* --- Print --- */

--- a/src/butterfly_planner/templates/base.html.j2
+++ b/src/butterfly_planner/templates/base.html.j2
@@ -100,12 +100,12 @@
         .tl-seg { flex: 1; min-width: 0; transition: opacity 0.15s; }
         .tl-seg:hover { opacity: 0.65; }
 
-        /* --- Sunshine color scale (muddy pale → bright lemon) --- */
-        .sunshine-none { background: #e8e8e8; }
-        .sunshine-low  { background: #f5eec2; }
-        .sunshine-med  { background: #f0e068; }
-        .sunshine-high { background: #f5e642; }
-        .sunshine-full { background: #fff44f; }
+        /* --- Sunshine color scale (warm sequential, monotonic lightness) --- */
+        .sunshine-none { background: #ececec; }
+        .sunshine-low  { background: #ffe8a3; }
+        .sunshine-med  { background: #ffc94d; }
+        .sunshine-high { background: #ff9e2c; }
+        .sunshine-full { background: #f4641b; }
 
         /* --- Inline hourly bar (16-day table) --- */
         .hour-bar { display: inline-flex; gap: 1px; vertical-align: middle; }
@@ -212,7 +212,7 @@
         .gdd-track-bar {
             flex: 1;
             height: 6px;
-            background: linear-gradient(to right, #4363d8, #ffd43b, #ff6b2b);
+            background: linear-gradient(to right, #4363d8, #ffc94d, #f4641b);
             border-radius: 3px;
             position: relative;
         }
@@ -329,8 +329,6 @@
                 font-weight: 600;
             }
             table.forecast-table tbody td:nth-child(2)::before { content: "Sun: "; }
-            table.forecast-table tbody td:nth-child(3)::before { content: ""; }
-            table.forecast-table tbody td:nth-child(4)::before { content: ""; }
             table.forecast-table tbody td:nth-child(5)::before { content: "Rain: "; }
             table.forecast-table tbody td:nth-child(6) {
                 grid-column: 1 / -1;

--- a/src/butterfly_planner/templates/sightings_table.html.j2
+++ b/src/butterfly_planner/templates/sightings_table.html.j2
@@ -2,7 +2,7 @@
 <p>Research-grade butterfly observations in NW Oregon / SW Washington
 during {{ period_label }}, {{ month_name }}
 (<a href="{{ all_obs_url }}">browse on iNaturalist</a>).</p>
-<table>
+<table class="sightings-table">
     <thead>
     <tr>
         <th></th>

--- a/src/butterfly_planner/templates/sunshine_16day.html.j2
+++ b/src/butterfly_planner/templates/sunshine_16day.html.j2
@@ -1,5 +1,5 @@
 <h2>16-Day Sunshine Forecast</h2>
-<table>
+<table class="forecast-table">
     <thead>
     <tr>
         <th>Date</th>

--- a/tests/test_flows_build.py
+++ b/tests/test_flows_build.py
@@ -598,7 +598,7 @@ class TestBuildButterflySightingsHtml:
         assert ">542<" in result
         assert "Cabbage White" in result
         assert "inaturalist.org/taxa/48662" in result
-        assert "<table>" in result
+        assert '<table class="sightings-table">' in result
         assert "<thead>" in result
 
     def test_with_photo(self) -> None:


### PR DESCRIPTION
## Summary
- **Responsive tables**: Sightings and 16-day forecast tables use "fat row" grid layouts on mobile (<640px) instead of overflowing horizontally
- **Vibrant sunshine palette**: Replaced brownish yellows (`#d4a017`, `#b8860b`) with warm vibrant colors (`#ffd43b` → `#ff922b` → `#ff6b2b`)
- **Mobile layout fixes**: Reduced map height, improved GDD card spacing, hidden hourly bars on small screens

## Changes
| File | What |
|------|------|
| `base.html.j2` | New `@media (max-width: 640px)` block with fat-row CSS, updated sunshine color scale |
| `sightings_table.html.j2` | Added `class="sightings-table"` for CSS targeting |
| `sunshine_16day.html.j2` | Added `class="forecast-table"` for CSS targeting |

## Color palette comparison

**Sunshine scale (before → after)**:
- None: `#e8e8e8` (unchanged gray)
- Low: `#f5eec2` → `#fff3b0` (warmer pale yellow)
- Med: `#e8d44d` → `#ffd43b` (bright golden)
- High: `#d4a017` → `#ff922b` (vibrant orange instead of dark gold)
- Full: `#b8860b` → `#ff6b2b` (bright orange-red instead of goldenrod/brown)

## Test plan
- [ ] Rebuild dashboard (`butterfly-planner refresh`) and view in browser
- [ ] Test at mobile viewport widths (320px, 375px, 414px)
- [ ] Verify sightings table stacks into fat rows without horizontal scroll
- [ ] Verify forecast table stacks into labeled grid without horizontal scroll
- [ ] Confirm new sunshine colors are vibrant and readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated color palette to warmer, more visually appealing tones
  * Adjusted GDD track bar gradient colors for improved visual consistency

* **New Features**
  * Enhanced mobile responsiveness with improved table layouts that reflow for smaller screens, reduced map height, and horizontal scrolling support for timeline views

* **Tests**
  * Updated test assertions to reflect styling and markup changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mihow/butterfly-planner/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->