### PR TITLE
refactor: extract analysis modules from renderers

### DIFF
--- a/src/butterfly_planner/analysis/__init__.py
+++ b/src/butterfly_planner/analysis/__init__.py
@@ -8,6 +8,8 @@ It never fetches data or produces HTML.
 
 Modules:
   - species_gdd: observations + GDD accumulation -> emergence profiles
+  - species_weather: observations + historical weather -> enriched observations
+  - weekly_forecast: sunshine + weather forecast -> date-keyed weather lookup
 
 Adding an analysis module
 -------------------------

--- a/src/butterfly_planner/analysis/species_weather.py
+++ b/src/butterfly_planner/analysis/species_weather.py
@@ -1,0 +1,34 @@
+"""Join butterfly observations with historical weather records.
+
+Matches weather data to observations by date, producing enriched
+observation dicts that renderers can consume directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def enrich_observations_with_weather(
+    observations: list[dict[str, Any]],
+    weather_by_date: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Attach historical weather data to observations by date.
+
+    For each observation, looks up the weather record for its ``observed_on``
+    date and adds a ``"weather"`` key with the matched record (or None).
+
+    Args:
+        observations: List of observation dicts with ``observed_on`` date strings.
+        weather_by_date: Mapping of ISO date string -> weather dict
+            (keys: ``high_c``, ``low_c``, ``precip_mm``, ``weather_code``).
+
+    Returns:
+        New list of observation dicts, each with an added ``"weather"`` key.
+    """
+    enriched: list[dict[str, Any]] = []
+    for obs in observations:
+        obs_date = obs.get("observed_on", "")
+        weather = weather_by_date.get(obs_date) if obs_date else None
+        enriched.append({**obs, "weather": weather})
+    return enriched

--- a/src/butterfly_planner/analysis/weekly_forecast.py
+++ b/src/butterfly_planner/analysis/weekly_forecast.py
@@ -1,0 +1,46 @@
+"""Merge sunshine and weather forecasts into a unified 16-day view.
+
+Combines the Open-Meteo daily sunshine forecast with the weather
+forecast, producing per-day records that the sunshine renderer can
+display directly without cross-datasource knowledge.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def merge_sunshine_weather(
+    weather_data: dict[str, Any] | None,
+) -> dict[str, dict[str, Any]]:
+    """Build a date-keyed weather lookup from a weather forecast envelope.
+
+    Extracts daily temperature, precipitation, and weather code from the
+    weather forecast and indexes them by ISO date string.
+
+    Args:
+        weather_data: Weather forecast envelope with
+            ``data.daily.{time, temperature_2m_max, temperature_2m_min,
+            precipitation_sum, weather_code}`` arrays.
+
+    Returns:
+        Dict mapping ISO date string -> weather record with keys
+        ``high_c``, ``low_c``, ``precip_mm``, ``weather_code``.
+        Empty dict if no weather data is available.
+    """
+    if not weather_data:
+        return {}
+
+    w_daily = weather_data.get("data", {}).get("daily", {})
+    w_dates = w_daily.get("time", [])
+
+    weather_by_date: dict[str, dict[str, Any]] = {}
+    for j, w_date in enumerate(w_dates):
+        weather_by_date[w_date] = {
+            "high_c": w_daily.get("temperature_2m_max", [None])[j],
+            "low_c": w_daily.get("temperature_2m_min", [None])[j],
+            "precip_mm": w_daily.get("precipitation_sum", [None])[j],
+            "weather_code": w_daily.get("weather_code", [None])[j],
+        }
+
+    return weather_by_date

--- a/src/butterfly_planner/renderers/sightings_map.py
+++ b/src/butterfly_planner/renderers/sightings_map.py
@@ -60,12 +60,14 @@ def _week_label(weeks: list[int]) -> str:
 def build_butterfly_map_html(
     inat_data: dict[str, Any],
     palette: dict[str, SpeciesStyle] | None = None,
-    historical_weather: dict[str, dict[str, Any]] | None = None,
 ) -> tuple[str, str]:
     """Build an interactive Leaflet map of butterfly observations.
 
     Each marker carries structured data so the JS template can build rich
     popups with thumbnail images and weather info.
+
+    Observations should be pre-enriched with a ``"weather"`` key (see
+    ``analysis.species_weather.enrich_observations_with_weather``).
 
     Returns a (map_div_html, map_script_js) tuple.
     """
@@ -86,8 +88,6 @@ def build_butterfly_map_html(
         species_list: list[dict[str, Any]] = data.get("species", [])
         palette = build_species_palette(species_list)
 
-    hw = historical_weather or {}
-
     # Build JS array of marker objects for the template.
     markers_js_parts: list[str] = []
     for obs in observations:
@@ -106,8 +106,8 @@ def build_butterfly_map_html(
         color = style.color if style else "#888"
         initials = style.initials if style else "?"
 
-        # Weather string for this observation's date
-        w = hw.get(obs_date)
+        # Weather from pre-enriched observation
+        w = obs.get("weather")
         weather_html = _escape_js(_build_weather_html(w)) if w else ""
 
         marker = (

--- a/src/butterfly_planner/renderers/sunshine.py
+++ b/src/butterfly_planner/renderers/sunshine.py
@@ -148,9 +148,14 @@ def _build_hourly_bar(slots: list[tuple[str, int, bool]]) -> str:
 
 
 def build_sunshine_16day_html(
-    sunshine_data: dict[str, Any], weather_data: dict[str, Any] | None = None
+    sunshine_data: dict[str, Any],
+    weather_by_date: dict[str, dict[str, Any]] | None = None,
 ) -> str:
-    """Build HTML for the merged 16-day forecast (sunshine + weather)."""
+    """Build HTML for the 16-day forecast (sunshine + pre-merged weather).
+
+    Weather data should be pre-merged via
+    ``analysis.weekly_forecast.merge_sunshine_weather``.
+    """
     daily = sunshine_data["daily_16day"].get("daily", {})
     dates = daily.get("time", [])
     sunshine_secs = daily.get("sunshine_duration", [])
@@ -159,18 +164,7 @@ def build_sunshine_16day_html(
     if not dates:
         return "<p>No 16-day sunshine data available.</p>"
 
-    weather_by_date: dict[str, dict[str, Any]] = {}
-    if weather_data:
-        w_daily = weather_data.get("data", {}).get("daily", {})
-        w_dates = w_daily.get("time", [])
-        for j, w_date in enumerate(w_dates):
-            weather_by_date[w_date] = {
-                "high_c": w_daily.get("temperature_2m_max", [None])[j],
-                "low_c": w_daily.get("temperature_2m_min", [None])[j],
-                "precip_mm": w_daily.get("precipitation_sum", [None])[j],
-                "weather_code": w_daily.get("weather_code", [None])[j],
-            }
-
+    weather_by_date = weather_by_date or {}
     slots_by_date = _group_15min_by_date(sunshine_data)
 
     rows = []

--- a/tests/test_species_weather.py
+++ b/tests/test_species_weather.py
@@ -1,0 +1,79 @@
+"""Tests for the species_weather analysis module."""
+
+from __future__ import annotations
+
+from butterfly_planner.analysis.species_weather import enrich_observations_with_weather
+
+
+class TestEnrichObservationsWithWeather:
+    """Test enriching observations with historical weather."""
+
+    def test_matching_dates(self) -> None:
+        """Test observations get weather attached for matching dates."""
+        observations = [
+            {"id": 1, "observed_on": "2024-06-15", "species": "Vanessa cardui"},
+            {"id": 2, "observed_on": "2024-06-10", "species": "Pieris rapae"},
+        ]
+        weather_by_date = {
+            "2024-06-15": {"high_c": 22.0, "low_c": 10.0, "precip_mm": 0.0, "weather_code": 0},
+            "2024-06-10": {"high_c": 18.0, "low_c": 8.0, "precip_mm": 2.5, "weather_code": 61},
+        }
+
+        result = enrich_observations_with_weather(observations, weather_by_date)
+
+        assert len(result) == 2
+        assert result[0]["weather"] == weather_by_date["2024-06-15"]
+        assert result[1]["weather"] == weather_by_date["2024-06-10"]
+        # Original fields preserved
+        assert result[0]["id"] == 1
+        assert result[0]["species"] == "Vanessa cardui"
+
+    def test_no_matching_date(self) -> None:
+        """Test observations without matching weather get None."""
+        observations = [
+            {"id": 1, "observed_on": "2024-06-15", "species": "Vanessa cardui"},
+        ]
+        weather_by_date = {
+            "2024-06-20": {"high_c": 22.0, "low_c": 10.0, "precip_mm": 0.0, "weather_code": 0},
+        }
+
+        result = enrich_observations_with_weather(observations, weather_by_date)
+
+        assert len(result) == 1
+        assert result[0]["weather"] is None
+
+    def test_empty_observations(self) -> None:
+        """Test with no observations returns empty list."""
+        result = enrich_observations_with_weather([], {"2024-06-15": {"high_c": 22.0}})
+        assert result == []
+
+    def test_empty_weather(self) -> None:
+        """Test with no weather data gives None weather on all observations."""
+        observations = [{"id": 1, "observed_on": "2024-06-15"}]
+        result = enrich_observations_with_weather(observations, {})
+
+        assert len(result) == 1
+        assert result[0]["weather"] is None
+
+    def test_missing_observed_on(self) -> None:
+        """Test observation without observed_on gets None weather."""
+        observations = [{"id": 1, "species": "Vanessa cardui"}]
+        weather_by_date = {
+            "2024-06-15": {"high_c": 22.0, "low_c": 10.0, "precip_mm": 0.0, "weather_code": 0},
+        }
+
+        result = enrich_observations_with_weather(observations, weather_by_date)
+
+        assert len(result) == 1
+        assert result[0]["weather"] is None
+
+    def test_does_not_mutate_originals(self) -> None:
+        """Test that original observation dicts are not modified."""
+        observations = [{"id": 1, "observed_on": "2024-06-15"}]
+        weather_by_date = {
+            "2024-06-15": {"high_c": 22.0, "low_c": 10.0, "precip_mm": 0.0, "weather_code": 0},
+        }
+
+        enrich_observations_with_weather(observations, weather_by_date)
+
+        assert "weather" not in observations[0]

--- a/tests/test_weekly_forecast.py
+++ b/tests/test_weekly_forecast.py
@@ -1,0 +1,72 @@
+"""Tests for the weekly_forecast analysis module."""
+
+from __future__ import annotations
+
+from butterfly_planner.analysis.weekly_forecast import merge_sunshine_weather
+
+
+class TestMergeSunshineWeather:
+    """Test merging weather forecast into date-keyed lookup."""
+
+    def test_basic_merge(self) -> None:
+        """Test extracting weather data into date-keyed dict."""
+        weather_data = {
+            "data": {
+                "daily": {
+                    "time": ["2026-02-04", "2026-02-05"],
+                    "temperature_2m_max": [15.0, 8.0],
+                    "temperature_2m_min": [5.0, 2.0],
+                    "precipitation_sum": [0.0, 5.2],
+                    "weather_code": [0, 61],
+                }
+            }
+        }
+
+        result = merge_sunshine_weather(weather_data)
+
+        assert len(result) == 2
+        assert result["2026-02-04"] == {
+            "high_c": 15.0,
+            "low_c": 5.0,
+            "precip_mm": 0.0,
+            "weather_code": 0,
+        }
+        assert result["2026-02-05"] == {
+            "high_c": 8.0,
+            "low_c": 2.0,
+            "precip_mm": 5.2,
+            "weather_code": 61,
+        }
+
+    def test_none_weather_data(self) -> None:
+        """Test with None weather data returns empty dict."""
+        result = merge_sunshine_weather(None)
+        assert result == {}
+
+    def test_empty_weather_data(self) -> None:
+        """Test with empty dict returns empty dict."""
+        result = merge_sunshine_weather({})
+        assert result == {}
+
+    def test_missing_daily_key(self) -> None:
+        """Test with missing daily key returns empty dict."""
+        result = merge_sunshine_weather({"data": {}})
+        assert result == {}
+
+    def test_missing_optional_arrays(self) -> None:
+        """Test with dates but missing weather arrays returns None values."""
+        weather_data = {
+            "data": {
+                "daily": {
+                    "time": ["2026-02-04"],
+                }
+            }
+        }
+
+        result = merge_sunshine_weather(weather_data)
+
+        assert len(result) == 1
+        assert result["2026-02-04"]["high_c"] is None
+        assert result["2026-02-04"]["low_c"] is None
+        assert result["2026-02-04"]["precip_mm"] is None
+        assert result["2026-02-04"]["weather_code"] is None


### PR DESCRIPTION
## Summary

- Extract `analysis/species_weather.py` — joins butterfly observations with historical weather by date. Previously inline in `renderers/sightings_map.py`.
- Extract `analysis/weekly_forecast.py` — merges weather forecast into a date-keyed lookup for the sunshine 16-day table. Previously inline in `renderers/sunshine.py`.
- Update `flows/build.py` to call analysis functions before passing data to renderers.
- Renderers now accept pre-joined data only (no cross-datasource knowledge).

## Test plan

- [x] New tests for `analysis/species_weather.py` (6 tests)
- [x] New tests for `analysis/weekly_forecast.py` (5 tests)
- [x] Updated existing renderer tests to pass pre-joined data
- [x] `make ci` passes (286 tests, lint, format, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)