### PR TITLE
feat: add structured daily data JSON format for multi-consumer use

### DIFF
--- a/docs/daily-data-format-options.md
+++ b/docs/daily-data-format-options.md
@@ -1,0 +1,179 @@
+# Structured Daily Data Format — Options
+
+**Date**: 2026-03-16
+**Status**: Option A implemented; others documented for future consideration
+
+## Problem
+
+The build pipeline transforms raw API data directly into HTML. There is no
+intermediate structured format that other consumers (iPhone widget, API,
+notifications) can use. We need a JSON representation of each day's data that
+is independent of both the upstream API shapes and the downstream HTML rendering.
+
+## Options
+
+### Option A: Daily Data Snapshot in Build Flow (Implemented)
+
+**Where**: New module `src/butterfly_planner/renderers/daily_data.py`
+**When**: Runs as a task in `flows/build.py`, alongside HTML generation
+**Output**: `data/derived/daily/<date>.json` + `data/derived/daily/today.json` (symlink/copy)
+
+The build flow already loads and transforms all the data. This option adds a
+pure function that extracts a structured `DailyData` dict from the same inputs
+the HTML renderers use, then writes it to the derived/ tier.
+
+**Schema** (see `daily_data.py` for the canonical definition):
+
+```json
+{
+  "version": "1.0",
+  "date": "2026-03-16",
+  "location": {"name": "Portland, OR", "lat": 45.5, "lon": -122.6},
+  "generated_at": "2026-03-16T10:30:00-07:00",
+  "sunshine": {
+    "today_hours": 4.2,
+    "daylight_hours": 11.8,
+    "sunshine_pct": 35.6,
+    "is_good_day": true,
+    "sunrise": "07:15",
+    "sunset": "19:05",
+    "hourly": [{"hour": 7, "sun_minutes": 8}, ...]
+  },
+  "weather": {
+    "high_c": 14.2,
+    "low_c": 6.1,
+    "precip_mm": 0.0,
+    "weather_code": 1,
+    "conditions": "Mostly Clear"
+  },
+  "gdd": {
+    "accumulated": 142.5,
+    "daily": 8.3,
+    "base_temp_f": 50,
+    "year_comparison": "+28 GDD ahead of last year"
+  },
+  "butterflies": {
+    "observation_window": {"start": "2026-03-02", "end": "2026-03-23"},
+    "species_count": 12,
+    "top_species": [
+      {"common_name": "Painted Lady", "scientific_name": "Vanessa cardui", "observation_count": 45}
+    ],
+    "recent_observations_count": 87
+  },
+  "forecast": [
+    {"date": "2026-03-17", "sunshine_hours": 5.1, "high_c": 15.0, "low_c": 7.2, ...},
+    ...
+  ]
+}
+```
+
+**Pros**:
+- Minimal new code — reuses existing data loading
+- Naturally fits the existing Prefect task graph
+- File-based output works for static hosting (widget can fetch `today.json`)
+- Schema versioned for forward compatibility
+
+**Cons**:
+- Coupled to the build flow schedule
+- File-based, so no dynamic queries
+
+---
+
+### Option B: Standalone CLI Command
+
+**Where**: New CLI command `butterfly-planner daily-json [--date DATE] [--output PATH]`
+**When**: Run on-demand or via cron, independent of the build flow
+
+Would add a new entry point that loads data from the store and produces a
+daily JSON file. Could target a specific date or default to today.
+
+```bash
+butterfly-planner daily-json                    # today → stdout
+butterfly-planner daily-json --date 2026-03-15  # specific date
+butterfly-planner daily-json --output daily.json
+```
+
+**Pros**:
+- Independent of the build flow — can run for historical dates
+- Good for scripting and piping to other tools
+- Can generate data for date ranges (e.g., backfill a week)
+
+**Cons**:
+- Duplicates data loading logic from build.py (or needs shared extraction)
+- Requires store to have data for the target date (no on-demand fetching)
+- More code to maintain
+
+**Implementation notes**: Would share the extraction function from Option A
+but wrap it in a CLI entry point using the existing Click CLI infrastructure.
+
+---
+
+### Option C: REST API Endpoint
+
+**Where**: New `src/butterfly_planner/services/api.py` using FastAPI/Litestar
+**When**: Always-on server, responds to HTTP requests
+
+```
+GET /api/v1/daily          → today's data
+GET /api/v1/daily/2026-03-15  → specific date
+GET /api/v1/forecast       → 16-day array
+```
+
+**Pros**:
+- Dynamic queries with filtering (species, date range, location)
+- Natural fit for mobile apps and widgets
+- Can compute data on-the-fly from the store
+- Supports authentication, rate limiting, CORS
+
+**Cons**:
+- Requires running a server (deployment complexity)
+- Overkill for the current static-site architecture
+- Need to manage uptime, scaling, caching
+
+**Implementation notes**: FastAPI is a natural choice. The daily data
+extraction function from Option A becomes the core of each endpoint handler.
+The store provides the data layer. Could be deployed as a single Fly.io or
+Railway container alongside the static site.
+
+---
+
+### Option D: Event-Driven with Webhooks
+
+**Where**: Extension to the fetch flow
+**When**: After each data fetch completes
+
+Each successful fetch would emit a webhook/notification with the updated
+daily data payload. Consumers register URLs to receive updates.
+
+```python
+# In flows/fetch.py, after saving data:
+daily = build_daily_data(weather, sunshine, inat, gdd)
+for url in settings.webhook_urls:
+    httpx.post(url, json=daily)
+```
+
+**Pros**:
+- Push-based — consumers get updates immediately
+- Good for real-time widgets and notifications
+- No polling needed
+
+**Cons**:
+- Requires webhook infrastructure (retries, delivery guarantees)
+- Consumers must run HTTP servers to receive
+- Complex error handling (what if a webhook is down?)
+- Premature for current scale
+
+---
+
+## Recommendation
+
+**Start with Option A** (implemented in this PR). It provides the structured
+data format with minimal complexity. The extraction function is pure and
+reusable, so Options B and C can build on it later:
+
+1. **Now**: Option A — daily JSON files in derived/
+2. **Soon**: Option B — CLI command for ad-hoc generation
+3. **Later**: Option C — REST API when we need dynamic queries
+4. **Eventually**: Option D — Webhooks for real-time consumers
+
+The `build_daily_data()` function is the shared foundation for all options.

--- a/docs/daily-data-format-options.md
+++ b/docs/daily-data-format-options.md
@@ -26,7 +26,7 @@ the HTML renderers use, then writes it to the derived/ tier.
 
 ```json
 {
-  "version": "1.0",
+  "version": "0.1",
   "date": "2026-03-16",
   "location": {"name": "Portland, OR", "lat": 45.5, "lon": -122.6},
   "generated_at": "2026-03-16T10:30:00-07:00",

--- a/src/butterfly_planner/flows/build.py
+++ b/src/butterfly_planner/flows/build.py
@@ -9,6 +9,7 @@ Run locally:
 
 from __future__ import annotations
 
+import json as json_mod
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -19,6 +20,7 @@ from prefect import flow, task
 from butterfly_planner.analysis.species_weather import enrich_observations_with_weather
 from butterfly_planner.analysis.weekly_forecast import merge_sunshine_weather
 from butterfly_planner.renderers import render_template
+from butterfly_planner.renderers.daily_data import build_daily_data
 from butterfly_planner.renderers.gdd import build_gdd_timeline_html, build_gdd_today_html
 from butterfly_planner.renderers.sightings_map import build_butterfly_map_html
 from butterfly_planner.renderers.sightings_table import build_butterfly_sightings_html
@@ -173,6 +175,42 @@ def build_html(
     )
 
 
+@task(name="build-daily-data")
+def build_daily_data_task(
+    weather_data: dict[str, Any] | None,
+    sunshine_data: dict[str, Any] | None,
+    inat_data: dict[str, Any] | None = None,
+    gdd_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build structured daily data JSON from all data sources."""
+    return build_daily_data(
+        weather_data=weather_data,
+        sunshine_data=sunshine_data,
+        inat_data=inat_data,
+        gdd_data=gdd_data,
+    )
+
+
+@task(name="write-daily-data")
+def write_daily_data(daily_data: dict[str, Any]) -> Path:
+    """Write daily data JSON to derived/daily/<date>.json and today.json."""
+    daily_dir = store.derived / "daily"
+    daily_dir.mkdir(parents=True, exist_ok=True)
+
+    date_str = daily_data.get("date", "unknown")
+    date_path = daily_dir / f"{date_str}.json"
+
+    with date_path.open("w") as f:
+        json_mod.dump(daily_data, f, indent=2)
+
+    # Also write as today.json for easy widget access
+    today_path = daily_dir / "today.json"
+    with today_path.open("w") as f:
+        json_mod.dump(daily_data, f, indent=2)
+
+    return date_path
+
+
 @task(name="write-site")
 def write_site(html: str) -> Path:
     """Write HTML to site directory."""
@@ -229,8 +267,13 @@ def build_all() -> dict[str, Any]:
     print("Writing site...")
     output_path = write_site(html)
 
+    print("Building daily data JSON...")
+    daily_data = build_daily_data_task(weather_envelope, sunshine, inat, gdd_data)
+    daily_path = write_daily_data(daily_data)
+    print(f"Daily data written: {daily_path}")
+
     print(f"Site built: {output_path}")
-    return {"pages": 1, "output": str(output_path)}
+    return {"pages": 1, "output": str(output_path), "daily_data": str(daily_path)}
 
 
 if __name__ == "__main__":

--- a/src/butterfly_planner/renderers/daily_data.py
+++ b/src/butterfly_planner/renderers/daily_data.py
@@ -1,0 +1,319 @@
+"""Structured daily data extraction for multi-consumer use.
+
+Transforms raw API data into a versioned, consumer-friendly JSON format.
+The output is independent of both upstream API shapes and downstream HTML
+rendering, suitable for widgets, mobile apps, and APIs.
+
+The canonical schema is defined by ``build_daily_data()`` — see the
+``docs/daily-data-format-options.md`` planning document for the full spec.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from butterfly_planner.analysis.weekly_forecast import merge_sunshine_weather
+from butterfly_planner.reference.viewing import MIN_GOOD_SUNSHINE_HOURS, MIN_GOOD_SUNSHINE_PCT
+from butterfly_planner.renderers.weather_utils import wmo_code_to_conditions
+
+# Schema version — bump on breaking changes
+SCHEMA_VERSION = "1.0"
+
+# Timezone for local display
+_PST = ZoneInfo("America/Los_Angeles")
+
+
+def build_daily_data(
+    weather_data: dict[str, Any] | None = None,
+    sunshine_data: dict[str, Any] | None = None,
+    inat_data: dict[str, Any] | None = None,
+    gdd_data: dict[str, Any] | None = None,
+    target_date: date | None = None,
+    location_name: str = "Portland, OR",
+    lat: float = 45.5,
+    lon: float = -122.6,
+) -> dict[str, Any]:
+    """Build structured daily data from all data sources.
+
+    This is a pure function that extracts and reshapes data for a single day.
+    It produces a versioned JSON-serializable dict suitable for file output,
+    API responses, or widget consumption.
+
+    Args:
+        weather_data: Weather forecast envelope (with ``data.daily`` arrays).
+        sunshine_data: Combined sunshine dict with ``today_15min`` and ``daily_16day``.
+        inat_data: iNaturalist envelope with ``data.species`` and ``data.observations``.
+        gdd_data: GDD envelope with ``data.current_year`` and ``data.previous_year``.
+        target_date: Date to extract data for (defaults to today).
+        location_name: Human-readable location label.
+        lat: Latitude.
+        lon: Longitude.
+
+    Returns:
+        Structured daily data dict with schema version.
+    """
+    today = target_date or date.today()
+    today_str = today.isoformat()
+    now = datetime.now(_PST)
+
+    result: dict[str, Any] = {
+        "version": SCHEMA_VERSION,
+        "date": today_str,
+        "location": {"name": location_name, "lat": lat, "lon": lon},
+        "generated_at": now.isoformat(),
+    }
+
+    result["sunshine"] = _extract_sunshine(sunshine_data, today_str)
+    result["weather"] = _extract_weather(weather_data, today_str)
+    result["gdd"] = _extract_gdd(gdd_data, today)
+    result["butterflies"] = _extract_butterflies(inat_data)
+    result["forecast"] = _extract_forecast(weather_data, sunshine_data, today_str)
+
+    return result
+
+
+def _extract_sunshine(
+    sunshine_data: dict[str, Any] | None, today_str: str
+) -> dict[str, Any] | None:
+    """Extract today's sunshine summary from 15-min and daily data."""
+    if not sunshine_data:
+        return None
+
+    # --- 15-min data for hourly breakdown ---
+    minutely = sunshine_data.get("today_15min", {}).get("minutely_15", {})
+    times = minutely.get("time", [])
+    durations = minutely.get("sunshine_duration", [])
+    is_day = minutely.get("is_day", [])
+
+    # Filter to today's daylight slots
+    daylight_slots: list[tuple[str, int]] = []
+    for i, t in enumerate(times):
+        if t[:10] == today_str and i < len(is_day) and is_day[i]:
+            daylight_slots.append((t, durations[i] if i < len(durations) else 0))
+
+    # Hourly aggregation
+    hours: dict[int, int] = {}
+    for time_str, dur in daylight_slots:
+        dt = datetime.fromisoformat(time_str)
+        hours.setdefault(dt.hour, 0)
+        hours[dt.hour] += dur
+
+    hourly = [{"hour": h, "sun_minutes": round(secs / 60, 1)} for h, secs in sorted(hours.items())]
+
+    total_sun_secs = sum(dur for _, dur in daylight_slots)
+    total_sun_hours = total_sun_secs / 3600
+
+    # Sunrise/sunset from first/last daylight slot
+    sunrise = ""
+    sunset = ""
+    if daylight_slots:
+        sunrise_dt = datetime.fromisoformat(daylight_slots[0][0])
+        sunset_dt = datetime.fromisoformat(daylight_slots[-1][0])
+        sunrise = sunrise_dt.strftime("%H:%M")
+        sunset = sunset_dt.strftime("%H:%M")
+
+    # --- Daily 16-day data for daylight duration ---
+    daily = sunshine_data.get("daily_16day", {}).get("daily", {})
+    daily_dates = daily.get("time", [])
+    daylight_secs_list = daily.get("daylight_duration", [])
+    sunshine_secs_list = daily.get("sunshine_duration", [])
+
+    daylight_hours = 0.0
+    sunshine_pct = 0.0
+    for i, d in enumerate(daily_dates):
+        if d == today_str:
+            day_sec = daylight_secs_list[i] if i < len(daylight_secs_list) else 0
+            sun_sec = sunshine_secs_list[i] if i < len(sunshine_secs_list) else 0
+            daylight_hours = (day_sec or 0) / 3600
+            sunshine_pct = (sun_sec / day_sec * 100) if day_sec else 0.0
+            # Prefer daily aggregate sunshine hours if no 15-min data
+            if not daylight_slots and sun_sec:
+                total_sun_hours = (sun_sec or 0) / 3600
+            break
+
+    is_good = total_sun_hours > MIN_GOOD_SUNSHINE_HOURS or sunshine_pct > MIN_GOOD_SUNSHINE_PCT
+
+    return {
+        "today_hours": round(total_sun_hours, 1),
+        "daylight_hours": round(daylight_hours, 1),
+        "sunshine_pct": round(sunshine_pct, 1),
+        "is_good_day": is_good,
+        "sunrise": sunrise,
+        "sunset": sunset,
+        "hourly": hourly,
+    }
+
+
+def _extract_weather(weather_data: dict[str, Any] | None, today_str: str) -> dict[str, Any] | None:
+    """Extract today's weather from the forecast data."""
+    if not weather_data:
+        return None
+
+    daily = weather_data.get("data", {}).get("daily", {})
+    dates = daily.get("time", [])
+
+    for i, d in enumerate(dates):
+        if d == today_str:
+            high = daily.get("temperature_2m_max", [None])[i]
+            low = daily.get("temperature_2m_min", [None])[i]
+            precip = daily.get("precipitation_sum", [None])[i]
+            code = daily.get("weather_code", [None])[i]
+            return {
+                "high_c": high,
+                "low_c": low,
+                "precip_mm": precip,
+                "weather_code": code,
+                "conditions": wmo_code_to_conditions(code) if code is not None else None,
+            }
+
+    return None
+
+
+def _extract_gdd(gdd_data: dict[str, Any] | None, today: date) -> dict[str, Any] | None:
+    """Extract today's GDD summary."""
+    if not gdd_data:
+        return None
+
+    data = gdd_data.get("data", {})
+    current = data.get("current_year", {})
+    previous = data.get("previous_year", {})
+    base_temp = data.get("base_temp_f", 50)
+
+    current_total = current.get("total_gdd", 0)
+
+    # Find today's daily GDD
+    daily_gdd = 0.0
+    today_str = today.isoformat()
+    for entry in current.get("daily", []):
+        if entry.get("date") == today_str:
+            daily_gdd = entry.get("daily_gdd", 0)
+            break
+
+    # Year comparison
+    today_doy = today.timetuple().tm_yday
+    previous_at_doy: float | None = None
+    for entry in previous.get("daily", []):
+        entry_date = date.fromisoformat(entry["date"])
+        if entry_date.timetuple().tm_yday >= today_doy:
+            previous_at_doy = entry.get("accumulated", 0)
+            break
+
+    year_comparison: str | None = None
+    if previous_at_doy is not None and previous_at_doy > 0:
+        diff = current_total - previous_at_doy
+        if abs(diff) / previous_at_doy > 0.05:
+            year_comparison = f"{diff:+.0f} GDD {'ahead of' if diff > 0 else 'behind'} last year"
+        else:
+            year_comparison = "Tracking close to last year"
+
+    return {
+        "accumulated": round(current_total, 1),
+        "daily": round(daily_gdd, 1),
+        "base_temp_f": base_temp,
+        "year_comparison": year_comparison,
+    }
+
+
+def _extract_butterflies(
+    inat_data: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Extract butterfly summary from iNaturalist data."""
+    if not inat_data:
+        return None
+
+    data = inat_data.get("data", {})
+    species_list: list[dict[str, Any]] = data.get("species", [])
+    observations: list[dict[str, Any]] = data.get("observations", [])
+
+    if not species_list:
+        return None
+
+    top_species = sorted(species_list, key=lambda s: s.get("observation_count", 0), reverse=True)[
+        :10
+    ]
+
+    return {
+        "observation_window": {
+            "start": data.get("date_start", ""),
+            "end": data.get("date_end", ""),
+        },
+        "species_count": len(species_list),
+        "top_species": [
+            {
+                "common_name": sp.get("common_name", ""),
+                "scientific_name": sp.get("scientific_name", ""),
+                "observation_count": sp.get("observation_count", 0),
+                "photo_url": sp.get("photo_url"),
+            }
+            for sp in top_species
+        ],
+        "recent_observations_count": len(observations),
+    }
+
+
+def _extract_forecast(
+    weather_data: dict[str, Any] | None,
+    sunshine_data: dict[str, Any] | None,
+    today_str: str,
+) -> list[dict[str, Any]]:
+    """Extract multi-day forecast array (excluding today).
+
+    Merges weather and sunshine data into per-day records for the
+    next 7 days.
+    """
+    if not weather_data:
+        return []
+
+    weather_by_date = merge_sunshine_weather(weather_data)
+
+    # Sunshine daily data
+    sun_daily = {}
+    if sunshine_data:
+        daily = sunshine_data.get("daily_16day", {}).get("daily", {})
+        dates = daily.get("time", [])
+        sun_secs = daily.get("sunshine_duration", [])
+        day_secs = daily.get("daylight_duration", [])
+        for i, d in enumerate(dates):
+            sun_sec = sun_secs[i] if i < len(sun_secs) and sun_secs[i] is not None else 0
+            day_sec = day_secs[i] if i < len(day_secs) and day_secs[i] is not None else 0
+            sun_daily[d] = {
+                "sunshine_hours": round(sun_sec / 3600, 1),
+                "daylight_hours": round(day_sec / 3600, 1),
+                "sunshine_pct": round(sun_sec / day_sec * 100, 1) if day_sec else 0.0,
+            }
+
+    forecast: list[dict[str, Any]] = []
+    w_daily = weather_data.get("data", {}).get("daily", {})
+    dates = w_daily.get("time", [])
+
+    for d in dates:
+        if d <= today_str:
+            continue
+        if len(forecast) >= 7:
+            break
+
+        w = weather_by_date.get(d, {})
+        sun = sun_daily.get(d, {})
+
+        code = w.get("weather_code")
+        entry: dict[str, Any] = {
+            "date": d,
+            "high_c": w.get("high_c"),
+            "low_c": w.get("low_c"),
+            "precip_mm": w.get("precip_mm"),
+            "weather_code": code,
+            "conditions": wmo_code_to_conditions(code) if code is not None else None,
+        }
+        entry.update(sun)
+
+        is_good = (
+            sun.get("sunshine_hours", 0) > MIN_GOOD_SUNSHINE_HOURS
+            or sun.get("sunshine_pct", 0) > MIN_GOOD_SUNSHINE_PCT
+        )
+        entry["is_good_day"] = is_good
+
+        forecast.append(entry)
+
+    return forecast

--- a/src/butterfly_planner/renderers/daily_data.py
+++ b/src/butterfly_planner/renderers/daily_data.py
@@ -18,8 +18,11 @@ from butterfly_planner.analysis.weekly_forecast import merge_sunshine_weather
 from butterfly_planner.reference.viewing import MIN_GOOD_SUNSHINE_HOURS, MIN_GOOD_SUNSHINE_PCT
 from butterfly_planner.renderers.weather_utils import wmo_code_to_conditions
 
-# Schema version — bump on breaking changes
-SCHEMA_VERSION = "1.0"
+# Schema version. 0.x = unstable/internal: fields (e.g. emoji in
+# `conditions`, window-vs-day `sunrise`/`sunset` semantics) may change
+# without a breaking bump until a real consumer validates the contract
+# and it is promoted to 1.0. Bump the major on breaking changes thereafter.
+SCHEMA_VERSION = "0.1"
 
 # Timezone for local display
 _PST = ZoneInfo("America/Los_Angeles")
@@ -54,7 +57,10 @@ def build_daily_data(
     Returns:
         Structured daily data dict with schema version.
     """
-    today = target_date or date.today()
+    # Default to the Pacific calendar day to match `generated_at` below;
+    # date.today() uses the (often UTC) runner clock, which writes the
+    # next day's file just after local midnight.
+    today = target_date or datetime.now(_PST).date()
     today_str = today.isoformat()
     now = datetime.now(_PST)
 

--- a/tests/test_daily_data.py
+++ b/tests/test_daily_data.py
@@ -1,0 +1,479 @@
+"""Tests for the structured daily data extraction module."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from butterfly_planner.renderers.daily_data import (
+    SCHEMA_VERSION,
+    build_daily_data,
+)
+
+# =============================================================================
+# Test fixtures
+# =============================================================================
+
+
+def _weather_envelope(dates: list[str] | None = None) -> dict[str, Any]:
+    """Build a weather envelope matching build.py's format."""
+    dates = dates or ["2026-03-16", "2026-03-17", "2026-03-18"]
+    n = len(dates)
+    return {
+        "fetched_at": "2026-03-16T12:00:00+00:00",
+        "source": "open-meteo.com",
+        "data": {
+            "daily": {
+                "time": dates,
+                "temperature_2m_max": [14.2] * n,
+                "temperature_2m_min": [6.1] * n,
+                "precipitation_sum": [0.0] * n,
+                "weather_code": [1] * n,
+            }
+        },
+    }
+
+
+def _sunshine_data(today: str = "2026-03-16") -> dict[str, Any]:
+    """Build sunshine data matching build.py's combined format."""
+    return {
+        "today_15min": {
+            "minutely_15": {
+                "time": [
+                    f"{today}T08:00:00",
+                    f"{today}T08:15:00",
+                    f"{today}T08:30:00",
+                    f"{today}T08:45:00",
+                    f"{today}T09:00:00",
+                    f"{today}T09:15:00",
+                    f"{today}T09:30:00",
+                    f"{today}T09:45:00",
+                ],
+                "sunshine_duration": [900, 900, 450, 0, 900, 900, 900, 900],
+                "is_day": [1, 1, 1, 1, 1, 1, 1, 1],
+            }
+        },
+        "daily_16day": {
+            "daily": {
+                "time": [today, "2026-03-17", "2026-03-18"],
+                "sunshine_duration": [21600, 14400, 3600],  # 6h, 4h, 1h
+                "daylight_duration": [43200, 43200, 43200],  # 12h each
+            }
+        },
+    }
+
+
+def _inat_data() -> dict[str, Any]:
+    """Build iNaturalist data matching build.py's envelope format."""
+    return {
+        "fetched_at": "2026-03-16T12:00:00",
+        "source": "inaturalist.org",
+        "data": {
+            "month": 3,
+            "date_start": "2026-03-02",
+            "date_end": "2026-03-23",
+            "species": [
+                {
+                    "taxon_id": 48662,
+                    "scientific_name": "Vanessa cardui",
+                    "common_name": "Painted Lady",
+                    "rank": "species",
+                    "observation_count": 45,
+                    "photo_url": "https://example.com/photo.jpg",
+                    "taxon_url": "https://www.inaturalist.org/taxa/48662",
+                },
+                {
+                    "taxon_id": 48548,
+                    "scientific_name": "Pieris rapae",
+                    "common_name": "Cabbage White",
+                    "rank": "species",
+                    "observation_count": 30,
+                    "photo_url": None,
+                    "taxon_url": "https://www.inaturalist.org/taxa/48548",
+                },
+            ],
+            "observations": [
+                {
+                    "id": 1,
+                    "species": "Vanessa cardui",
+                    "common_name": "Painted Lady",
+                    "observed_on": "2024-03-15",
+                    "latitude": 45.52,
+                    "longitude": -122.68,
+                    "quality_grade": "research",
+                    "url": "https://www.inaturalist.org/observations/1",
+                    "photo_url": "https://example.com/obs1.jpg",
+                },
+            ],
+        },
+    }
+
+
+def _gdd_data() -> dict[str, Any]:
+    """Build GDD data matching build.py's envelope format."""
+    return {
+        "fetched_at": "2026-03-16T12:00:00",
+        "source": "open-meteo.com (archive)",
+        "data": {
+            "base_temp_f": 50,
+            "current_year": {
+                "year": 2026,
+                "total_gdd": 142.5,
+                "daily": [
+                    {"date": "2026-03-15", "daily_gdd": 7.0, "accumulated": 134.2},
+                    {"date": "2026-03-16", "daily_gdd": 8.3, "accumulated": 142.5},
+                ],
+            },
+            "previous_year": {
+                "year": 2025,
+                "total_gdd": 280.0,
+                "daily": [
+                    {"date": "2025-03-15", "daily_gdd": 5.0, "accumulated": 110.0},
+                    {"date": "2025-03-16", "daily_gdd": 4.5, "accumulated": 114.5},
+                ],
+            },
+        },
+    }
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+class TestBuildDailyDataEnvelope:
+    """Test the top-level structure of build_daily_data output."""
+
+    def test_schema_version(self) -> None:
+        result = build_daily_data(target_date=date(2026, 3, 16))
+        assert result["version"] == SCHEMA_VERSION
+
+    def test_date_field(self) -> None:
+        result = build_daily_data(target_date=date(2026, 3, 16))
+        assert result["date"] == "2026-03-16"
+
+    def test_location(self) -> None:
+        result = build_daily_data(
+            target_date=date(2026, 3, 16),
+            location_name="Portland, OR",
+            lat=45.5,
+            lon=-122.6,
+        )
+        assert result["location"]["name"] == "Portland, OR"
+        assert result["location"]["lat"] == 45.5
+        assert result["location"]["lon"] == -122.6
+
+    def test_generated_at_is_iso(self) -> None:
+        result = build_daily_data(target_date=date(2026, 3, 16))
+        assert "T" in result["generated_at"]
+
+    def test_all_sections_present(self) -> None:
+        result = build_daily_data(target_date=date(2026, 3, 16))
+        assert "sunshine" in result
+        assert "weather" in result
+        assert "gdd" in result
+        assert "butterflies" in result
+        assert "forecast" in result
+
+    def test_empty_inputs_produce_none_sections(self) -> None:
+        result = build_daily_data(target_date=date(2026, 3, 16))
+        assert result["sunshine"] is None
+        assert result["weather"] is None
+        assert result["gdd"] is None
+        assert result["butterflies"] is None
+        assert result["forecast"] == []
+
+
+class TestSunshineExtraction:
+    """Test sunshine data extraction."""
+
+    def test_sunshine_hours(self) -> None:
+        result = build_daily_data(
+            sunshine_data=_sunshine_data(),
+            target_date=date(2026, 3, 16),
+        )
+        sun = result["sunshine"]
+        assert sun is not None
+        # 8 slots: 900+900+450+0+900+900+900+900 = 5850 sec = 1.625h
+        assert sun["today_hours"] == 1.6
+
+    def test_sunshine_daylight_from_daily(self) -> None:
+        result = build_daily_data(
+            sunshine_data=_sunshine_data(),
+            target_date=date(2026, 3, 16),
+        )
+        sun = result["sunshine"]
+        assert sun is not None
+        assert sun["daylight_hours"] == 12.0
+
+    def test_sunshine_pct(self) -> None:
+        result = build_daily_data(
+            sunshine_data=_sunshine_data(),
+            target_date=date(2026, 3, 16),
+        )
+        sun = result["sunshine"]
+        assert sun is not None
+        # 21600 sun / 43200 daylight = 50%
+        assert sun["sunshine_pct"] == 50.0
+
+    def test_good_day_detection(self) -> None:
+        result = build_daily_data(
+            sunshine_data=_sunshine_data(),
+            target_date=date(2026, 3, 16),
+        )
+        sun = result["sunshine"]
+        assert sun is not None
+        # 50% sunshine > 40% threshold → good day
+        assert sun["is_good_day"] is True
+
+    def test_sunrise_sunset(self) -> None:
+        result = build_daily_data(
+            sunshine_data=_sunshine_data(),
+            target_date=date(2026, 3, 16),
+        )
+        sun = result["sunshine"]
+        assert sun is not None
+        assert sun["sunrise"] == "08:00"
+        assert sun["sunset"] == "09:45"
+
+    def test_hourly_breakdown(self) -> None:
+        result = build_daily_data(
+            sunshine_data=_sunshine_data(),
+            target_date=date(2026, 3, 16),
+        )
+        sun = result["sunshine"]
+        assert sun is not None
+        assert len(sun["hourly"]) == 2  # hours 8 and 9
+        assert sun["hourly"][0]["hour"] == 8
+        assert sun["hourly"][1]["hour"] == 9
+
+    def test_no_sunshine_data(self) -> None:
+        result = build_daily_data(target_date=date(2026, 3, 16))
+        assert result["sunshine"] is None
+
+
+class TestWeatherExtraction:
+    """Test weather data extraction."""
+
+    def test_today_weather(self) -> None:
+        result = build_daily_data(
+            weather_data=_weather_envelope(),
+            target_date=date(2026, 3, 16),
+        )
+        w = result["weather"]
+        assert w is not None
+        assert w["high_c"] == 14.2
+        assert w["low_c"] == 6.1
+        assert w["precip_mm"] == 0.0
+        assert w["weather_code"] == 1
+        assert "Mostly Clear" in w["conditions"]
+
+    def test_no_matching_date(self) -> None:
+        result = build_daily_data(
+            weather_data=_weather_envelope(["2026-03-20"]),
+            target_date=date(2026, 3, 16),
+        )
+        assert result["weather"] is None
+
+    def test_no_weather_data(self) -> None:
+        result = build_daily_data(target_date=date(2026, 3, 16))
+        assert result["weather"] is None
+
+
+class TestGDDExtraction:
+    """Test GDD data extraction."""
+
+    def test_accumulated_gdd(self) -> None:
+        result = build_daily_data(
+            gdd_data=_gdd_data(),
+            target_date=date(2026, 3, 16),
+        )
+        g = result["gdd"]
+        assert g is not None
+        assert g["accumulated"] == 142.5
+
+    def test_daily_gdd(self) -> None:
+        result = build_daily_data(
+            gdd_data=_gdd_data(),
+            target_date=date(2026, 3, 16),
+        )
+        g = result["gdd"]
+        assert g is not None
+        assert g["daily"] == 8.3
+
+    def test_year_comparison(self) -> None:
+        result = build_daily_data(
+            gdd_data=_gdd_data(),
+            target_date=date(2026, 3, 16),
+        )
+        g = result["gdd"]
+        assert g is not None
+        # 142.5 vs 114.5 = +28, ratio 1.24 > 1.05 → ahead
+        assert "ahead" in g["year_comparison"]
+
+    def test_base_temp(self) -> None:
+        result = build_daily_data(
+            gdd_data=_gdd_data(),
+            target_date=date(2026, 3, 16),
+        )
+        g = result["gdd"]
+        assert g is not None
+        assert g["base_temp_f"] == 50
+
+    def test_no_gdd_data(self) -> None:
+        result = build_daily_data(target_date=date(2026, 3, 16))
+        assert result["gdd"] is None
+
+
+class TestButterflyExtraction:
+    """Test butterfly data extraction."""
+
+    def test_species_count(self) -> None:
+        result = build_daily_data(
+            inat_data=_inat_data(),
+            target_date=date(2026, 3, 16),
+        )
+        b = result["butterflies"]
+        assert b is not None
+        assert b["species_count"] == 2
+
+    def test_top_species(self) -> None:
+        result = build_daily_data(
+            inat_data=_inat_data(),
+            target_date=date(2026, 3, 16),
+        )
+        b = result["butterflies"]
+        assert b is not None
+        assert len(b["top_species"]) == 2
+        # Sorted by count descending
+        assert b["top_species"][0]["common_name"] == "Painted Lady"
+        assert b["top_species"][0]["observation_count"] == 45
+
+    def test_observation_window(self) -> None:
+        result = build_daily_data(
+            inat_data=_inat_data(),
+            target_date=date(2026, 3, 16),
+        )
+        b = result["butterflies"]
+        assert b is not None
+        assert b["observation_window"]["start"] == "2026-03-02"
+        assert b["observation_window"]["end"] == "2026-03-23"
+
+    def test_observation_count(self) -> None:
+        result = build_daily_data(
+            inat_data=_inat_data(),
+            target_date=date(2026, 3, 16),
+        )
+        b = result["butterflies"]
+        assert b is not None
+        assert b["recent_observations_count"] == 1
+
+    def test_no_inat_data(self) -> None:
+        result = build_daily_data(target_date=date(2026, 3, 16))
+        assert result["butterflies"] is None
+
+    def test_empty_species(self) -> None:
+        empty = {"data": {"species": [], "observations": []}}
+        result = build_daily_data(
+            inat_data=empty,
+            target_date=date(2026, 3, 16),
+        )
+        assert result["butterflies"] is None
+
+
+class TestForecastExtraction:
+    """Test forecast array extraction."""
+
+    def test_excludes_today(self) -> None:
+        result = build_daily_data(
+            weather_data=_weather_envelope(),
+            target_date=date(2026, 3, 16),
+        )
+        forecast = result["forecast"]
+        dates = [f["date"] for f in forecast]
+        assert "2026-03-16" not in dates
+
+    def test_includes_future_days(self) -> None:
+        result = build_daily_data(
+            weather_data=_weather_envelope(),
+            target_date=date(2026, 3, 16),
+        )
+        forecast = result["forecast"]
+        assert len(forecast) == 2  # 03-17 and 03-18
+        assert forecast[0]["date"] == "2026-03-17"
+
+    def test_forecast_has_weather_fields(self) -> None:
+        result = build_daily_data(
+            weather_data=_weather_envelope(),
+            target_date=date(2026, 3, 16),
+        )
+        forecast = result["forecast"]
+        assert len(forecast) > 0
+        day = forecast[0]
+        assert "high_c" in day
+        assert "low_c" in day
+        assert "precip_mm" in day
+        assert "conditions" in day
+        assert "is_good_day" in day
+
+    def test_forecast_with_sunshine(self) -> None:
+        result = build_daily_data(
+            weather_data=_weather_envelope(),
+            sunshine_data=_sunshine_data(),
+            target_date=date(2026, 3, 16),
+        )
+        forecast = result["forecast"]
+        assert len(forecast) > 0
+        day = forecast[0]
+        assert "sunshine_hours" in day
+        assert "daylight_hours" in day
+        assert "sunshine_pct" in day
+
+    def test_forecast_max_7_days(self) -> None:
+        dates = [f"2026-03-{d:02d}" for d in range(16, 30)]
+        result = build_daily_data(
+            weather_data=_weather_envelope(dates),
+            target_date=date(2026, 3, 16),
+        )
+        assert len(result["forecast"]) == 7
+
+    def test_empty_forecast_without_weather(self) -> None:
+        result = build_daily_data(target_date=date(2026, 3, 16))
+        assert result["forecast"] == []
+
+
+class TestFullIntegration:
+    """Test with all data sources combined."""
+
+    def test_all_sources(self) -> None:
+        result = build_daily_data(
+            weather_data=_weather_envelope(),
+            sunshine_data=_sunshine_data(),
+            inat_data=_inat_data(),
+            gdd_data=_gdd_data(),
+            target_date=date(2026, 3, 16),
+        )
+        assert result["version"] == SCHEMA_VERSION
+        assert result["sunshine"] is not None
+        assert result["weather"] is not None
+        assert result["gdd"] is not None
+        assert result["butterflies"] is not None
+        assert len(result["forecast"]) > 0
+
+    def test_json_serializable(self) -> None:
+        """Verify the output can be serialized to JSON."""
+        import json  # noqa: PLC0415
+
+        result = build_daily_data(
+            weather_data=_weather_envelope(),
+            sunshine_data=_sunshine_data(),
+            inat_data=_inat_data(),
+            gdd_data=_gdd_data(),
+            target_date=date(2026, 3, 16),
+        )
+        # Should not raise
+        serialized = json.dumps(result)
+        assert len(serialized) > 100
+        # Round-trip
+        parsed = json.loads(serialized)
+        assert parsed["version"] == SCHEMA_VERSION


### PR DESCRIPTION
Add an intermediate JSON data layer between raw API data and HTML rendering.
The build flow now outputs `derived/daily/<date>.json` and `today.json`
alongside the HTML site, enabling widget and app consumers.

Includes planning doc (docs/daily-data-format-options.md) evaluating 4
approaches: file-based (implemented), CLI, REST API, and webhooks.

https://claude.ai/code/session_01T8P653f7aHDxNeuFwgz8fZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily data is now generated and included in build output, providing structured information on weather, sunshine, butterfly observations, and growing degree days with a 7-day forecast.

* **Documentation**
  * Added documentation outlining structured daily data format options and design recommendations.

* **Tests**
  * Added comprehensive test coverage for daily data generation across all data sources and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->