### PR TITLE
fix: cluster 1 safe bug fixes (#30, #32, #33)

### DIFF
--- a/src/butterfly_planner/datasources/inaturalist/observations.py
+++ b/src/butterfly_planner/datasources/inaturalist/observations.py
@@ -70,7 +70,7 @@ def _parse_observation(obs: dict[str, Any]) -> ButterflyObservation | None:
         longitude=lon,
         quality_grade=obs.get("quality_grade", "casual"),
         url=f"https://www.inaturalist.org/observations/{obs['id']}",
-        photo_url=photos[0]["url"] if photos else None,
+        photo_url=photos[0].get("url") if photos else None,
     )
 
 
@@ -108,8 +108,6 @@ def fetch_observations_for_month(
         "month": month_str,
         "quality_grade": quality_grade,
         "verifiable": "true",
-        "order": "desc",
-        "order_by": "observed_on",
     }
 
     raw = client.get_observations_paginated(params, max_pages=max_pages)

--- a/src/butterfly_planner/datasources/inaturalist/species.py
+++ b/src/butterfly_planner/datasources/inaturalist/species.py
@@ -149,7 +149,7 @@ def summarize_species(species: list[SpeciesRecord]) -> dict[str, Any]:
     """
     Create a summary of species data for reporting.
 
-    Returns dict with top_species, total count, and family breakdown.
+    Returns dict with top_species, total count, and rank breakdown.
     """
     if not species:
         return {"total_species": 0, "top_species": [], "by_rank": {}}

--- a/src/butterfly_planner/datasources/inaturalist/weekly.py
+++ b/src/butterfly_planner/datasources/inaturalist/weekly.py
@@ -7,7 +7,7 @@ for a given ISO week, plus week-to-month conversion helpers.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from butterfly_planner.datasources.inaturalist import client
@@ -41,7 +41,7 @@ class OccurrenceSummary:
     total_species: int
     total_observations: int
     weeks: list[int] = field(default_factory=list)
-    fetched_at: datetime = field(default_factory=datetime.now)
+    fetched_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
     @property
     def top_species(self) -> list[SpeciesRecord]:
@@ -130,7 +130,7 @@ def _week_range(center_week: int, *, radius: int = 1) -> list[int]:
     """
     Return a list of ISO week numbers centered on *center_week*.
 
-    Wraps around year boundaries (week 1 +/- 1 -> [52, 1, 2]).
+    Wraps around year boundaries (week 1 - 1 -> 52; week 53 + 1 -> 1).
 
     Args:
         center_week: The center ISO week number (1-53).
@@ -144,8 +144,8 @@ def _week_range(center_week: int, *, radius: int = 1) -> list[int]:
         w = center_week + offset
         if w < 1:
             w += 52
-        elif w > 52:
-            w -= 52
+        elif w > 53:
+            w -= 53
         weeks.append(w)
     return sorted(weeks)
 

--- a/src/butterfly_planner/datasources/sunshine/daily.py
+++ b/src/butterfly_planner/datasources/sunshine/daily.py
@@ -33,7 +33,7 @@ def fetch_16day_sunshine(
         "forecast_days": 16,
     }
 
-    resp = session.get(FORECAST_API, params=params)
+    resp = session.get(FORECAST_API, params=params, timeout=60)
     resp.raise_for_status()
     data: dict[str, Any] = resp.json()
 
@@ -45,10 +45,16 @@ def fetch_16day_sunshine(
 
     forecasts = []
     for i, date_str in enumerate(dates):
+        raw_sun = sunshine_secs[i]
+        raw_day = daylight_secs[i]
+        if raw_sun is None or raw_day is None:
+            continue
         dt = date.fromisoformat(date_str)
         forecasts.append(
             DailySunshine(
-                date=dt, sunshine_seconds=sunshine_secs[i], daylight_seconds=daylight_secs[i]
+                date=dt,
+                sunshine_seconds=int(raw_sun),
+                daylight_seconds=int(raw_day),
             )
         )
 

--- a/src/butterfly_planner/datasources/sunshine/ensemble.py
+++ b/src/butterfly_planner/datasources/sunshine/ensemble.py
@@ -57,7 +57,7 @@ def fetch_ensemble_sunshine(
     forecasts = []
     for i, time_str in enumerate(times):
         dt = datetime.fromisoformat(time_str)
-        member_values = [hourly[key][i] for key in member_keys]
+        member_values = [int(hourly[key][i]) for key in member_keys if hourly[key][i] is not None]
         forecasts.append(EnsembleSunshine(time=dt, member_values=member_values))
 
     return forecasts

--- a/src/butterfly_planner/flows/build.py
+++ b/src/butterfly_planner/flows/build.py
@@ -10,7 +10,7 @@ Run locally:
 from __future__ import annotations
 
 import json as json_mod
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -125,7 +125,8 @@ def build_html(
     historical_weather: dict[str, dict[str, Any]] | None = None,
 ) -> str:
     """Build HTML page from weather, sunshine, iNaturalist, and GDD data."""
-    fetched_dt = datetime.fromisoformat(weather_data["fetched_at"])
+    _raw_fetched_at = weather_data.get("fetched_at") or ""
+    fetched_dt = datetime.fromisoformat(_raw_fetched_at) if _raw_fetched_at else datetime.now(UTC)
     pst = ZoneInfo("America/Los_Angeles")
     local_dt = fetched_dt.astimezone(pst)
     updated = local_dt.strftime("%Y-%m-%d %H:%M")

--- a/src/butterfly_planner/renderers/sunshine.py
+++ b/src/butterfly_planner/renderers/sunshine.py
@@ -185,7 +185,7 @@ def build_sunshine_16day_html(
             bar = f'<div class="sunshine-bar" style="width: {bar_width}px;"></div>'
 
         w = weather_by_date.get(date_str)
-        if w and w["high_c"] is not None:
+        if w and w["high_c"] is not None and w["low_c"] is not None:
             temp_cell = (
                 f'<span class="temp-high">{w["high_c"]:.0f}\u00b0C</span> / '
                 f'<span class="temp-low">{w["low_c"]:.0f}\u00b0C</span>'

--- a/src/butterfly_planner/store.py
+++ b/src/butterfly_planner/store.py
@@ -84,7 +84,7 @@ class DataStore:
         if valid_until is not None:
             meta["valid_until"] = valid_until.isoformat()
         if params:
-            meta.update(params)
+            meta["params"] = dict(params)
 
         envelope = {"meta": meta, "data": data}
         with full.open("w") as f:
@@ -110,7 +110,7 @@ class DataStore:
             src: Source file to copy into the store.
             source: Data source identifier.
             valid_until: Expiry timestamp.
-            **params: Extra metadata fields.
+            **params: Extra metadata fields stored under ``meta["params"]``.
 
         Returns:
             Absolute path of the stored file.
@@ -126,7 +126,7 @@ class DataStore:
         if valid_until is not None:
             meta["valid_until"] = valid_until.isoformat()
         if params:
-            meta.update(params)
+            meta["params"] = dict(params)
 
         meta_path = full.with_suffix(full.suffix + ".meta.json")
         with meta_path.open("w") as f:

--- a/tests/test_flows_build.py
+++ b/tests/test_flows_build.py
@@ -954,3 +954,50 @@ class TestBuildAllFlow:
         assert "16-Day Sunshine Forecast" in html_content
         assert "Butterfly Sightings" in html_content
         assert "Painted Lady" in html_content
+
+
+# =============================================================================
+# Tests for #33 — fetched_at empty-string runtime bug
+# =============================================================================
+
+
+class TestBuildHtmlFetchedAtFallback:
+    """build_html must not crash when fetched_at is empty or missing.
+
+    Calls build_html.fn() directly to bypass the Prefect task runner,
+    which requires a live Prefect server in this environment.
+    """
+
+    def test_build_html_empty_fetched_at_does_not_raise(self) -> None:
+        """build_html with fetched_at='' should not raise ValueError."""
+        weather_data = {
+            "fetched_at": "",  # triggers datetime.fromisoformat("") → ValueError
+            "data": {
+                "daily": {
+                    "time": ["2026-02-04"],
+                    "temperature_2m_max": [15.0],
+                    "temperature_2m_min": [5.0],
+                    "precipitation_sum": [0],
+                    "weather_code": [0],
+                }
+            },
+        }
+        # Call .fn() to bypass the Prefect task runner (no server needed)
+        result = build.build_html.fn(weather_data, None)
+        assert "<!DOCTYPE html>" in result
+
+    def test_build_html_missing_fetched_at_does_not_raise(self) -> None:
+        """build_html with no fetched_at key should not raise KeyError/ValueError."""
+        weather_data = {
+            "data": {
+                "daily": {
+                    "time": ["2026-02-04"],
+                    "temperature_2m_max": [15.0],
+                    "temperature_2m_min": [5.0],
+                    "precipitation_sum": [0],
+                    "weather_code": [0],
+                }
+            }
+        }
+        result = build.build_html.fn(weather_data, None)
+        assert "<!DOCTYPE html>" in result

--- a/tests/test_inaturalist.py
+++ b/tests/test_inaturalist.py
@@ -508,9 +508,11 @@ class TestWeekRange:
         weeks = _week_range(1)
         assert weeks == [1, 2, 52]
 
-    def test_week_52_wraps_to_1(self) -> None:
+    def test_week_52_includes_53(self) -> None:
+        # Previously wrapped w=53 to w=1 (bug: skipped week 53 entirely).
+        # After fix: week 53 is a valid ISO week and should appear as-is.
         weeks = _week_range(52)
-        assert weeks == [1, 51, 52]
+        assert weeks == [51, 52, 53]
 
     def test_custom_radius(self) -> None:
         weeks = _week_range(10, radius=2)
@@ -644,6 +646,88 @@ class TestInatClient:
 # =============================================================================
 # Default Bounding Box Tests
 # =============================================================================
+
+
+# =============================================================================
+# Tests for #30 — observations.py: photos[0]["url"] → .get("url")
+# =============================================================================
+
+
+class TestParseObservationPhotoUrl:
+    """_parse_observation must not crash when photos entry has no 'url' key."""
+
+    def test_photo_with_no_url_key_returns_none(self) -> None:
+        """Photo dict missing 'url' key should yield photo_url=None."""
+        obs = {
+            "id": 200001,
+            "location": "45.5,-122.6",
+            "observed_on": "2025-06-15",
+            "quality_grade": "research",
+            "taxon": {"name": "Vanessa cardui"},
+            "photos": [{"thumbnail_url": "https://example.com/thumb.jpg"}],  # no "url" key
+        }
+        result = _parse_observation(obs)
+        assert result is not None
+        assert result.photo_url is None
+
+    def test_empty_photos_list_returns_none(self) -> None:
+        """Empty photos list should yield photo_url=None (no crash)."""
+        obs = {
+            "id": 200002,
+            "location": "45.5,-122.6",
+            "observed_on": "2025-06-15",
+            "quality_grade": "research",
+            "taxon": {"name": "Vanessa cardui"},
+            "photos": [],
+        }
+        result = _parse_observation(obs)
+        assert result is not None
+        assert result.photo_url is None
+
+    def test_photo_url_present_is_used(self) -> None:
+        """When url key exists, it should be used."""
+        obs = {
+            "id": 200003,
+            "location": "45.5,-122.6",
+            "observed_on": "2025-06-15",
+            "quality_grade": "research",
+            "taxon": {"name": "Vanessa cardui"},
+            "photos": [{"url": "https://example.com/photo.jpg"}],
+        }
+        result = _parse_observation(obs)
+        assert result is not None
+        assert result.photo_url == "https://example.com/photo.jpg"
+
+
+# =============================================================================
+# Tests for #32 — weekly.py: _week_range week-53 wrapping
+# =============================================================================
+
+
+class TestWeekRangeWeek53:
+    """_week_range must handle week-53 years correctly."""
+
+    def test_week_53_wraps_correctly(self) -> None:
+        """Week 53 center should wrap to week 1 and 2 (not 53+1=54)."""
+        weeks = _week_range(53)
+        # Expected: [1, 2, 53] — week 53 center with radius 1
+        assert 53 in weeks
+        assert 1 in weeks
+        assert 54 not in weeks
+        assert all(1 <= w <= 53 for w in weeks)
+
+    def test_week_52_with_radius_1_wraps_to_53(self) -> None:
+        """Week 52 center should include week 53 when applicable."""
+        weeks = _week_range(52)
+        # With old %52 logic: (53-1)%52+1 = 1, not 53 — that's the bug
+        # Current code: w=53 > 52 → w-=52 → w=1 (also skips 53!)
+        # Correct: 53 should be reachable
+        # After fix: weeks should contain 51, 52, 53
+        assert 52 in weeks
+        assert 51 in weeks
+        # Should not wrap 53 to 1 (that's the bug to fix)
+        # After fix: w=53 → w should be 53, not 1
+        assert 53 in weeks
 
 
 class TestDefaultBoundingBox:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -44,7 +44,8 @@ class TestDataStoreWrite:
         assert data["meta"]["valid_until"] == valid.isoformat()
         assert data["data"] == {"temp": 20}
 
-    def test_write_extra_params(self, tmp_path: Path) -> None:
+    def test_write_extra_params_nested_under_params(self, tmp_path: Path) -> None:
+        """Extra **params must be nested under meta['params'], not merged into meta."""
         store = DataStore(tmp_path)
         store.write(
             Path("live/test.json"),
@@ -53,7 +54,31 @@ class TestDataStoreWrite:
             location={"lat": 45.5, "lon": -122.6},
         )
         data = json.loads((tmp_path / "live" / "test.json").read_text())
-        assert data["meta"]["location"] == {"lat": 45.5, "lon": -122.6}
+        # Params must live under meta["params"], not directly on meta
+        assert "params" in data["meta"]
+        assert data["meta"]["params"]["location"] == {"lat": 45.5, "lon": -122.6}
+        # Reserved keys must not be overwritten by caller params
+        assert data["meta"]["source"] == "test"
+        assert "fetched_at" in data["meta"]
+
+    def test_write_source_cannot_be_overwritten_by_params(self, tmp_path: Path) -> None:
+        """Caller passing source= in **params must not overwrite the reserved meta['source']."""
+        store = DataStore(tmp_path)
+        store.write(
+            Path("live/test.json"),
+            {},
+            source="real-source",
+            # Attempting to overwrite via params — should be nested, not overwrite
+        )
+        data = json.loads((tmp_path / "live" / "test.json").read_text())
+        assert data["meta"]["source"] == "real-source"
+
+    def test_write_no_extra_params_no_params_key(self, tmp_path: Path) -> None:
+        """When no extra params passed, meta['params'] key should not exist."""
+        store = DataStore(tmp_path)
+        store.write(Path("live/test.json"), {}, source="test")
+        data = json.loads((tmp_path / "live" / "test.json").read_text())
+        assert "params" not in data["meta"]
 
     def test_write_creates_parent_dirs(self, tmp_path: Path) -> None:
         store = DataStore(tmp_path)

--- a/tests/test_sunshine.py
+++ b/tests/test_sunshine.py
@@ -10,6 +10,9 @@ from unittest.mock import Mock, patch
 import pytest
 
 from butterfly_planner.datasources import sunshine
+from butterfly_planner.datasources.sunshine.daily import fetch_16day_sunshine
+from butterfly_planner.datasources.sunshine.ensemble import fetch_ensemble_sunshine
+from butterfly_planner.renderers.sunshine import build_sunshine_16day_html
 
 
 class TestSunshineSlot:
@@ -384,3 +387,155 @@ class TestAnalysisFunctions:
         # Next week only has 3 days (indices 7-9)
         if summary["next_week"]:  # Only check if dict is not empty
             assert summary["next_week"]["total_days"] == 3
+
+
+# =============================================================================
+# Tests for #33 — sunshine renderer: low_c None guard
+# =============================================================================
+
+
+class TestBuildSunshine16DayHtmlNullTemps:
+    """16-day HTML renderer must not crash when low_c or high_c is None."""
+
+    def test_low_c_none_does_not_crash(self) -> None:
+        """high_c present but low_c=None must not raise TypeError in format()."""
+        sunshine_data = {
+            "today_15min": {"minutely_15": {"time": [], "sunshine_duration": [], "is_day": []}},
+            "daily_16day": {
+                "daily": {
+                    "time": ["2026-02-04"],
+                    "sunshine_duration": [14400],
+                    "daylight_duration": [36000],
+                }
+            },
+        }
+        weather_by_date = {
+            "2026-02-04": {
+                "high_c": 15.0,
+                "low_c": None,  # This triggers the bug
+                "precip_mm": 0.0,
+                "weather_code": 0,
+            }
+        }
+        # Should not raise TypeError from {w["low_c"]:.0f}
+        result = build_sunshine_16day_html(sunshine_data, weather_by_date)
+        assert "—" in result  # Falls back to em-dash when either temp is None
+
+    def test_high_c_none_does_not_crash(self) -> None:
+        """high_c=None must produce em-dash, not crash."""
+        sunshine_data = {
+            "today_15min": {"minutely_15": {"time": [], "sunshine_duration": [], "is_day": []}},
+            "daily_16day": {
+                "daily": {
+                    "time": ["2026-02-04"],
+                    "sunshine_duration": [14400],
+                    "daylight_duration": [36000],
+                }
+            },
+        }
+        weather_by_date = {
+            "2026-02-04": {
+                "high_c": None,
+                "low_c": 5.0,
+                "precip_mm": 0.0,
+                "weather_code": 0,
+            }
+        }
+        result = build_sunshine_16day_html(sunshine_data, weather_by_date)
+        assert "—" in result
+
+
+# =============================================================================
+# Tests for #30 — daily.py: float/None coercion for DailySunshine fields
+# =============================================================================
+
+
+class TestFetch16DaySunshineFloatCoercion:
+    """fetch_16day_sunshine must coerce float/None values to int for DailySunshine."""
+
+    @patch("butterfly_planner.datasources.sunshine.daily.session.get")
+    def test_float_values_coerced_to_int(self, mock_get: Mock) -> None:
+        """API returning float seconds should be coerced to int."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "daily": {
+                "time": ["2026-02-04"],
+                "sunshine_duration": [14400.7],  # float from API
+                "daylight_duration": [36000.2],  # float from API
+            }
+        }
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        forecasts = fetch_16day_sunshine(lat=45.5, lon=-122.6)
+        assert len(forecasts) == 1
+        assert isinstance(forecasts[0].sunshine_seconds, int)
+        assert isinstance(forecasts[0].daylight_seconds, int)
+        assert forecasts[0].sunshine_seconds == 14400
+
+    @patch("butterfly_planner.datasources.sunshine.daily.session.get")
+    def test_none_values_handled(self, mock_get: Mock) -> None:
+        """API returning None for sunshine/daylight should be handled gracefully."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "daily": {
+                "time": ["2026-02-04"],
+                "sunshine_duration": [None],
+                "daylight_duration": [None],
+            }
+        }
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        # Should skip None entries rather than crashing
+        forecasts = fetch_16day_sunshine(lat=45.5, lon=-122.6)
+        assert len(forecasts) == 0  # None entry skipped
+
+
+# =============================================================================
+# Tests for #30 — ensemble.py: None filtering and int coercion
+# =============================================================================
+
+
+class TestFetchEnsembleSunshineNoneFiltering:
+    """fetch_ensemble_sunshine must filter None values and coerce floats."""
+
+    @patch("butterfly_planner.datasources.sunshine.ensemble.session.get")
+    def test_none_members_filtered(self, mock_get: Mock) -> None:
+        """None values in ensemble member lists should be filtered out."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "hourly": {
+                "time": ["2026-02-04T12:00"],
+                "sunshine_duration_member00": [1800],
+                "sunshine_duration_member01": [None],  # missing member value
+                "sunshine_duration_member02": [2100],
+            }
+        }
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        forecasts = fetch_ensemble_sunshine(lat=45.5, lon=-122.6)
+        assert len(forecasts) == 1
+        # None filtered: 3 members → 2 valid
+        assert len(forecasts[0].member_values) == 2
+        assert None not in forecasts[0].member_values
+
+    @patch("butterfly_planner.datasources.sunshine.ensemble.session.get")
+    def test_float_members_coerced(self, mock_get: Mock) -> None:
+        """Float values in ensemble member lists should be coerced to int."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "hourly": {
+                "time": ["2026-02-04T12:00"],
+                "sunshine_duration_member00": [1800.5],
+                "sunshine_duration_member01": [2100.9],
+            }
+        }
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        forecasts = fetch_ensemble_sunshine(lat=45.5, lon=-122.6)
+        assert len(forecasts) == 1
+        assert all(isinstance(v, int) for v in forecasts[0].member_values)
+        assert forecasts[0].member_values == [1800, 2100]


### PR DESCRIPTION
## Summary

Addresses three issues from PR #28 code review. All fixes are isolated, defensive, and accompanied by new tests.

## Fixes by issue

### Closes #33 — Runtime crash bugs (highest risk)

**`flows/build.py` — empty `fetched_at` raises `ValueError`**
`datetime.fromisoformat("")` crashes when `weather_data["fetched_at"]` is an empty string (the fallback when `meta.fetched_at` is absent from a cached file). The call now falls back to `datetime.now(UTC)` when the value is empty or missing. Tested via `build_html.fn()` to bypass the Prefect task runner.

**`renderers/sunshine.py` — `low_c` None crash**
The 16-day table guard checked `w["high_c"] is not None` but then formatted `w["low_c"]` unconditionally. When the archive API returns a null low temperature, this raised `TypeError`. The guard now also checks `w["low_c"] is not None`.

**`store.py` — caller params could overwrite reserved meta keys**
`meta.update(params)` allowed `**kwargs` callers to silently overwrite `source` and `fetched_at`. Extra params are now nested under `meta["params"]` so reserved top-level keys are protected.

### Closes #30 — Defensive parsing

**`datasources/inaturalist/observations.py`** — `photos[0]["url"]` replaced with `photos[0].get("url")` so a photo dict without a `url` key returns `None` instead of raising `KeyError`.

**`datasources/sunshine/daily.py`** — adds `timeout=60` (matching ensemble.py); skips entries where sunshine or daylight is `None`; coerces `float` API values to `int` for `DailySunshine` fields.

**`datasources/sunshine/ensemble.py`** — filters `None` member values and coerces `float` to `int` during ensemble list construction.

### Closes #32 — Dead code and consistency

**`datasources/inaturalist/observations.py`** — removes dead `order`/`order_by` params from `fetch_observations_for_month`; the paginator (`get_observations_paginated`) sets its own ordering internally and the caller params were silently ignored.

**`datasources/inaturalist/weekly.py`** — `OccurrenceSummary.fetched_at` default factory used naive `datetime.now()`; changed to `datetime.now(UTC)`. `_week_range` used `% 52` wrapping that made week 53 unreachable (mapped 53+1=54 to 1, skipping 53 entirely); fixed to allow valid week-53 years.

**`datasources/inaturalist/species.py`** — docstring said "family breakdown" for the `by_rank` field; corrected to "rank breakdown" to match what the code computes.

## Test approach

Tests were written before fixes (red → green). New tests use `build_html.fn()` to bypass the Prefect task runner, which requires a live Prefect server that appears unavailable in this environment due to an alembic migration mismatch (`a1b2c3d4e5f7` revision not found). This is a pre-existing environment issue unrelated to these changes; 271/271 non-Prefect tests pass.

## What still needs verification

- The `meta["params"]` nesting change is a breaking change to the stored envelope format. Any code that reads `meta["location"]` or other custom params directly off `meta` (rather than `meta["params"]`) will need updating. A grep of the repo found no such production readers — only the test that was updated. Confirm this holds if new callers are added.
- The week-53 `_week_range` fix changes the returned list for `_week_range(52)` from `[1, 51, 52]` to `[51, 52, 53]`. Downstream month-conversion logic in `_weeks_to_months` and `_week_to_months` should handle week 53 correctly; not measured in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)