### PR TITLE
fix(map): safe JSON serialization for map markers, SRI hash, slider direction fix

### DIFF
--- a/src/butterfly_planner/renderers/sightings_map.py
+++ b/src/butterfly_planner/renderers/sightings_map.py
@@ -6,7 +6,10 @@ for rich popups with thumbnail images and weather info.
 
 from __future__ import annotations
 
+import json
 from typing import Any
+
+from pydantic import BaseModel
 
 from butterfly_planner.renderers import render_template
 from butterfly_planner.renderers.date_utils import date_range_label, year_range
@@ -17,9 +20,46 @@ from butterfly_planner.renderers.species_palette import (
 from butterfly_planner.renderers.weather_utils import wmo_code_to_conditions
 
 
-def _escape_js(text: str) -> str:
-    """Escape a string for safe embedding inside a JS double-quoted string."""
-    return text.replace("\\", "\\\\").replace('"', '\\"').replace("'", "\\'")
+class _MarkerData(BaseModel):
+    """Structured marker data serialized as JSON into the map script."""
+
+    lat: float
+    lon: float
+    name: str
+    species: str
+    date: str
+    url: str
+    photo: str
+    color: str
+    initials: str
+    weather: str
+
+
+def _safe_json(obj: Any) -> str:
+    """Serialize *obj* to a JSON string safe for embedding in a <script> block.
+
+    json.dumps escapes ``"`` and ``\\`` by default.  Three additional sequences
+    are unsafe inside a ``<script>`` block even inside a string literal:
+
+    * ``</`` — closes the enclosing ``<script>`` element when the browser
+      HTML-parses the document before executing JS.
+    * U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) — treated as
+      line terminators by JS engines; they break string literals when
+      unescaped.  Python's json.dumps does NOT escape them by default.
+
+    ``ensure_ascii=False`` is intentional: non-ASCII characters in names are
+    preserved as UTF-8 rather than being mangled into ``\\uXXXX`` sequences,
+    which keeps popup text readable.  The three dangerous sequences above are
+    the only ones that need explicit post-processing.
+    """
+    serialized = json.dumps(obj, ensure_ascii=False)
+    # Escape </script> injection: replace </ with <\/
+    # (the backslash is legal in a JSON string and ignored by JS)
+    serialized = serialized.replace("</", "<\\/")
+    # Escape U+2028 / U+2029 — illegal unescaped in JS string literals
+    serialized = serialized.replace(chr(0x2028), "\\u2028")
+    serialized = serialized.replace(chr(0x2029), "\\u2029")
+    return serialized
 
 
 def _build_weather_html(w: dict[str, Any]) -> str:
@@ -28,7 +68,7 @@ def _build_weather_html(w: dict[str, Any]) -> str:
     if w.get("weather_code") is not None:
         parts.append(wmo_code_to_conditions(w["weather_code"]))
     if w.get("high_c") is not None and w.get("low_c") is not None:
-        parts.append(f"{w['high_c']:.0f}/{w['low_c']:.0f}\u00b0C")
+        parts.append(f"{w['high_c']:.0f}/{w['low_c']:.0f}°C")
     if w.get("precip_mm") is not None and w["precip_mm"] > 0:
         parts.append(f"{w['precip_mm']:.1f}mm")
     return " &middot; ".join(parts)
@@ -64,8 +104,8 @@ def build_butterfly_map_html(
         species_list: list[dict[str, Any]] = data.get("species", [])
         palette = build_species_palette(species_list)
 
-    # Build JS array of marker objects for the template.
-    markers_js_parts: list[str] = []
+    # Build list of typed marker objects; serialize once with _safe_json.
+    markers: list[_MarkerData] = []
     for obs in observations:
         lat = obs.get("latitude")
         lon = obs.get("longitude")
@@ -84,24 +124,24 @@ def build_butterfly_map_html(
 
         # Weather from pre-enriched observation
         w = obs.get("weather")
-        weather_html = _escape_js(_build_weather_html(w)) if w else ""
+        weather_html = _build_weather_html(w) if w else ""
 
-        marker = (
-            "{"
-            f"lat:{lat},lon:{lon},"
-            f'name:"{_escape_js(name)}",'
-            f'species:"{_escape_js(species)}",'
-            f'date:"{_escape_js(obs_date)}",'
-            f'url:"{_escape_js(url)}",'
-            f'photo:"{_escape_js(photo_url)}",'
-            f'color:"{color}",'
-            f'initials:"{_escape_js(initials)}",'
-            f'weather:"{weather_html}"'
-            "}"
+        markers.append(
+            _MarkerData(
+                lat=lat,
+                lon=lon,
+                name=name,
+                species=species,
+                date=obs_date,
+                url=url,
+                photo=photo_url,
+                color=color,
+                initials=initials,
+                weather=weather_html,
+            )
         )
-        markers_js_parts.append(marker)
 
-    markers_js = "[" + ",".join(markers_js_parts) + "]"
+    markers_json = _safe_json([m.model_dump() for m in markers])
     years = year_range(observations)
 
     map_div = render_template(
@@ -113,7 +153,7 @@ def build_butterfly_map_html(
 
     map_script = render_template(
         "sightings_map_script.html.j2",
-        markers_json=markers_js,
+        markers_json=markers_json,
     )
 
     return (map_div, map_script)

--- a/src/butterfly_planner/templates/base.html.j2
+++ b/src/butterfly_planner/templates/base.html.j2
@@ -436,7 +436,8 @@
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
             crossorigin=""></script>
     <script src="https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js?v={{ build_version }}"
-            crossorigin=""></script>
+            integrity="sha384-mFKkGiGvT5vo1fEyGCD3hshDdKmW3wzXW/x+fWriYJArD0R3gawT6lMvLboM22c0"
+            crossorigin="anonymous"></script>
     {{ map_script|safe }}
 </body>
 </html>

--- a/src/butterfly_planner/templates/sightings_map_script.html.j2
+++ b/src/butterfly_planner/templates/sightings_map_script.html.j2
@@ -24,8 +24,9 @@
     return html;
   }
 
-  // --- Sightings marker layer ---
+  // --- Sightings marker layer + heat map points (built in one pass) ---
   var markers = L.layerGroup();
+  var heatPoints = [];
   for (var i = 0; i < obs.length; i++) {
     var o = obs[i];
     var m = L.circleMarker([o.lat, o.lon], {
@@ -36,15 +37,10 @@
     m.bindTooltip(o.initials, {permanent: true, direction: "center",
       className: "map-label", offset: [0, 0]});
     markers.addLayer(m);
-  }
-
-  // --- Density heat map layer ---
-  var heatPoints = [];
-  for (var j = 0; j < obs.length; j++) {
-    heatPoints.push([obs[j].lat, obs[j].lon]);
+    heatPoints.push([o.lat, o.lon]);
   }
   // Auto-scale intensity: fewer observations → lower max → more vivid colors.
-  // With 5 obs, max ≈ 0.15; with 20, max ≈ 0.35; with 80+, max ≈ 1.0.
+  // With 5 obs, max ≈ 0.15; with 20, max ≈ 0.45; with 48+, max ≈ 1.0.
   var defaultMax = Math.max(0.08, Math.min(1.0, 0.05 + obs.length * 0.02));
   var heat = L.heatLayer(heatPoints, {
     radius: 18,
@@ -59,17 +55,21 @@
     options: { position: 'bottomright' },
     onAdd: function() {
       var container = L.DomUtil.create('div', 'leaflet-bar heat-intensity-control');
+      // Slider value is the "reciprocal scale" 1–20: leftmost=1 (heat max 1.0,
+      // 100% intensity), rightmost=20 (heat max 0.05, 2000% intensity).
+      // This ensures the label ascends left→right (100%→2000%).
+      var initSlider = Math.round(1 / defaultMax);
       container.innerHTML =
         '<label for="heat-intensity-slider">Intensity</label>' +
-        '<input id="heat-intensity-slider" type="range" min="0.05" max="1.0" step="0.01" value="' + defaultMax.toFixed(2) + '">' +
+        '<input id="heat-intensity-slider" type="range" min="1" max="20" step="1" value="' + initSlider + '">' +
         '<span class="heat-intensity-value">' + Math.round((1 / defaultMax) * 100) + '%</span>';
       var slider = container.querySelector('input');
       var label = container.querySelector('.heat-intensity-value');
       L.DomEvent.disableClickPropagation(container);
       slider.addEventListener('input', function() {
-        var val = parseFloat(this.value);
+        var val = 1 / parseFloat(this.value);
         heat.setOptions({max: val});
-        label.textContent = Math.round((1 / val) * 100) + '%';
+        label.textContent = Math.round(parseFloat(this.value) * 100) + '%';
       });
       return container;
     }

--- a/tests/test_flows_build.py
+++ b/tests/test_flows_build.py
@@ -651,10 +651,10 @@ class TestBuildButterflyMapHtml:
         # Weather should appear for the matching date
         assert "Clear" in map_script
         assert "22/10" in map_script
-        # Object-based markers (not array)
-        assert "lat:" in map_script
-        assert "name:" in map_script
-        assert "weather:" in map_script
+        # Object-based markers serialized as JSON (quoted property names)
+        assert '"lat":' in map_script
+        assert '"name":' in map_script
+        assert '"weather":' in map_script
 
     def test_map_without_historical_weather(self) -> None:
         """Test map works without historical weather data."""
@@ -742,6 +742,24 @@ class TestHeatMapIntensitySlider:
         _, map_script = build_butterfly_map_html(SAMPLE_INAT_DATA_WITH_OBS)
 
         assert "heat.setOptions" in map_script
+
+    def test_slider_direction_ascending(self) -> None:
+        """Slider must ascend left-to-right (min < max, label increases with position).
+
+        The slider value is an inverse scale 1-20; higher slider position means
+        lower heat ``max`` which produces higher displayed intensity %. The label
+        must read 100% at the left end (slider=1) and up to 2000% at the right
+        (slider=20).
+        """
+        _, map_script = build_butterfly_map_html(SAMPLE_INAT_DATA_WITH_OBS)
+
+        # Slider input range must be inverted scale (1 to 20), not raw heat max
+        assert 'min="1"' in map_script
+        assert 'max="20"' in map_script
+        # On change, val = 1/slider so heat max stays in [0.05, 1.0]
+        assert "1 / parseFloat(this.value)" in map_script
+        # Label reflects slider * 100 (ascending: 100% at slider=1, 2000% at slider=20)
+        assert "parseFloat(this.value) * 100" in map_script
 
 
 class TestBuildButterflySightingsHtml:

--- a/tests/test_sightings_map_escaping.py
+++ b/tests/test_sightings_map_escaping.py
@@ -1,0 +1,205 @@
+"""
+Tests for safe JS/JSON embedding in sightings_map renderer.
+
+Adversarial test suite: verifies that user/data-derived strings injected into
+the <script> block cannot break the JS context or enable XSS.
+
+Covers #31 (manual string escaping -> json.dumps) and associated CVEs for:
+  - </script> tag injection
+  - Embedded newlines (raw newlines break a JS string literal)
+  - U+2028 / U+2029 (line/paragraph separators; invalid unescaped in JS)
+  - Single/double quotes
+  - Backslash injection
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from butterfly_planner.renderers.sightings_map import build_butterfly_map_html
+
+# U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR as string constants so
+# ruff RUF001 does not flag ambiguous literal characters in the source.
+_LS = chr(0x2028)
+_PS = chr(0x2029)
+
+
+def _make_inat(common_name: str, species: str = "Vanessa cardui") -> dict:
+    """Build a minimal iNat payload with a single observation using the given name."""
+    return {
+        "data": {
+            "date_start": "2026-06-01",
+            "date_end": "2026-06-15",
+            "species": [
+                {
+                    "taxon_id": 1,
+                    "scientific_name": species,
+                    "common_name": common_name,
+                    "observation_count": 1,
+                }
+            ],
+            "observations": [
+                {
+                    "id": 1,
+                    "species": species,
+                    "common_name": common_name,
+                    "observed_on": "2026-06-10",
+                    "latitude": 45.52,
+                    "longitude": -122.68,
+                    "quality_grade": "research",
+                    "url": "https://www.inaturalist.org/observations/1",
+                    "photo_url": None,
+                }
+            ],
+        }
+    }
+
+
+def _extract_markers_json(map_script: str) -> list[dict]:
+    """
+    Extract the JSON array from ``var obs = <array>;`` in the rendered script.
+
+    Raises ValueError if the pattern is not found or the JSON is invalid.
+    """
+    match = re.search(r"var obs\s*=\s*(\[.*?\]);", map_script, re.DOTALL)
+    if not match:
+        raise ValueError(f"Could not find 'var obs = [...]' in script:\n{map_script[:500]}")
+    return json.loads(match.group(1))
+
+
+class TestScriptTagInjection:
+    """Ensure </script> in data does not close the enclosing script block."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "</script>",
+            "</script><script>alert(1)</script>",
+            "</SCRIPT>",
+            "</ script>",
+            "</script\n>",
+        ],
+    )
+    def test_no_premature_script_close(self, name: str) -> None:
+        """The rendered HTML must not contain a bare </script> that closes the block."""
+        _, map_script = build_butterfly_map_html(_make_inat(name))
+        # The only valid </script> should be the one closing the template block
+        # itself. The injected name must NOT produce an unescaped </script>
+        # inside the JSON.
+        script_close_count = map_script.lower().count("</script>")
+        assert script_close_count <= 1, (
+            f"Found {script_close_count} </script> occurrences with name={name!r}"
+        )
+        # Also assert the injected value appears escaped in the JSON
+        markers = _extract_markers_json(map_script)
+        assert markers[0]["name"] == name, "Round-trip through JSON must preserve the name"
+
+    def test_script_tag_value_survives_roundtrip(self) -> None:
+        """The raw </script> value must parse back correctly from the JSON."""
+        name = "</script>"
+        _, map_script = build_butterfly_map_html(_make_inat(name))
+        markers = _extract_markers_json(map_script)
+        assert markers[0]["name"] == name
+
+
+class TestNewlineEmbedding:
+    """Embedded newlines must not break the JS string literal."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Painted\nLady",
+            "Painted\rLady",
+            "Painted\r\nLady",
+        ],
+    )
+    def test_newline_in_name(self, name: str) -> None:
+        """Newlines in the name must be escaped so the JSON is valid."""
+        _, map_script = build_butterfly_map_html(_make_inat(name))
+        markers = _extract_markers_json(map_script)
+        assert markers[0]["name"] == name, "Newline chars must survive round-trip"
+
+
+class TestUnicodeSeparators:
+    """U+2028 and U+2029 are line/paragraph separators, illegal unescaped in JS."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            f"Painted{_LS}Lady",  # LINE SEPARATOR
+            f"Painted{_PS}Lady",  # PARAGRAPH SEPARATOR
+            f"{_LS}{_PS}Both",
+        ],
+    )
+    def test_unicode_separators_escaped(self, name: str) -> None:
+        """U+2028/U+2029 must appear as \\u2028/\\u2029 in the rendered script."""
+        _, map_script = build_butterfly_map_html(_make_inat(name))
+        # The raw characters must NOT appear in the script source
+        assert _LS not in map_script, "Raw U+2028 found in script -- must be escaped"
+        assert _PS not in map_script, "Raw U+2029 found in script -- must be escaped"
+        # But the value must round-trip correctly
+        markers = _extract_markers_json(map_script)
+        assert markers[0]["name"] == name
+
+
+class TestQuoteAndBackslashEscaping:
+    """Single/double quotes and backslashes must not break the JSON string."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            'Say "hello"',
+            "It's alive",
+            "Both ' and \"",
+            "Back\\slash",
+            'Back\\slash and "quotes"',
+            "\\'\\\"",  # already-escaped characters
+        ],
+    )
+    def test_quotes_and_backslash(self, name: str) -> None:
+        """Quotes and backslashes must survive round-trip without breaking JSON."""
+        _, map_script = build_butterfly_map_html(_make_inat(name))
+        markers = _extract_markers_json(map_script)
+        assert markers[0]["name"] == name
+
+
+class TestCombinedAdversarialInput:
+    """Combined adversarial string with multiple attack vectors."""
+
+    def test_combined_attack_string(self) -> None:
+        """A name combining all attack vectors must render safely."""
+        name = f"</script><script>alert(1)</script>\n\r{_LS}{_PS}\"'\\xss"
+        _, map_script = build_butterfly_map_html(_make_inat(name))
+
+        # No bare </script> break (only the template's own closing tag allowed)
+        assert map_script.lower().count("</script>") <= 1
+
+        # No raw U+2028/U+2029
+        assert _LS not in map_script
+        assert _PS not in map_script
+
+        # Round-trip
+        markers = _extract_markers_json(map_script)
+        assert markers[0]["name"] == name
+
+    def test_adversarial_weather_html(self) -> None:
+        """Weather HTML (another injected string) must also be escaped properly."""
+        name = "Normal Butterfly"
+        weather = {
+            "high_c": 22.0,
+            "low_c": 10.0,
+            "precip_mm": 0.0,
+            "weather_code": 0,
+        }
+        inat_data = _make_inat(name)
+        # Inject weather via obs enrichment
+        inat_data["data"]["observations"][0]["weather"] = weather
+        _, map_script = build_butterfly_map_html(inat_data)
+        # Weather appears in the JSON under "weather" key
+        markers = _extract_markers_json(map_script)
+        assert isinstance(markers[0].get("weather"), str)
+        # Script must remain parseable (no premature close)
+        assert map_script.lower().count("</script>") <= 1


### PR DESCRIPTION
## Problem

`sightings_map.py` built the Leaflet marker array by manual string concatenation, using `_escape_js()` that only handled `\`, `"`, and `'`. This left three classes of injection unaddressed:

- **`</script>` tag injection**: a `common_name` containing `</script>` would close the enclosing `<script>` block in the HTML parser before JS execution, enabling script injection.
- **Embedded newlines**: raw `\n`/`\r` in a JS string literal cause a syntax error; the old escaper didn't touch them.
- **U+2028 / U+2029**: JavaScript line/paragraph separators — they break string literals when unescaped but `_escape_js` didn't handle them.

## Fix (#31)

- Replace manual concatenation with a `_MarkerData` Pydantic model and `json.dumps` serialization.
- Add `_safe_json()` that post-processes `json.dumps` output to escape the three remaining danger sequences:
  - `</` → `<\/` (prevents premature script close)
  - `chr(0x2028)` → ` ` (literal 6-char escape text)
  - `chr(0x2029)` → ` `
- Remove `_escape_js` (no other callers).
- Add `tests/test_sightings_map_escaping.py` with 20 adversarial test cases (TDD: written before the fix, confirmed failing, now all pass).

## #67 extras

**Done:**
- **SRI hash**: Added `integrity="sha384-..."` and `crossorigin="anonymous"` to the `leaflet-heat.js` CDN tag in `base.html.j2`. Hash computed from the live `unpkg.com/leaflet.heat@0.2.0` file.
- **heatPoints loop merge**: Folded the separate `heatPoints` construction loop into the existing markers loop (single pass, no logic change).
- **Auto-scale comment**: Fixed factual error — 20 obs yields max ≈ 0.45 (not 0.35 as stated); saturation is at ~48 obs (not 80+).
- **Intensity slider direction (Bug C)**: The slider was descending — leftmost position showed 2000%, rightmost 100%. Fixed using an inverted 1-20 scale: slider value = `round(1/defaultMax)`; on change `heat max = 1/slider_value`, label = `slider_value * 100 + '%'`. Now ascends 100%→2000% left to right. Added `test_slider_direction_ascending` to verify.

**Not done:** None — all low-priority #67 items were folded in.

## Tests

20 new adversarial tests in `tests/test_sightings_map_escaping.py`:
- `TestScriptTagInjection` (6 cases): `</script>`, XSS payload, case variants, whitespace variant
- `TestNewlineEmbedding` (3 cases): `\n`, `\r`, `\r\n`
- `TestUnicodeSeparators` (3 cases): U+2028, U+2029, combined
- `TestQuoteAndBackslashEscaping` (6 cases): various quote/backslash combinations
- `TestCombinedAdversarialInput` (2 cases): combined attack string, adversarial weather HTML

All 35 map-related tests pass (20 new + 15 pre-existing). Lint, format-check, and pyright all clean.

Closes #31
Closes #67